### PR TITLE
agent skills bundles

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(rbuilder:*)"
+    ]
+  },
+  "skills": [
+    "skills/rbuilder-orient",
+    "skills/rbuilder-impact",
+    "skills/rbuilder-session",
+    "skills/rbuilder-neighborhood",
+    "skills/rbuilder-slice",
+    "skills/rbuilder-security",
+    "skills/rbuilder-migration",
+    "skills/rbuilder-ci-gate"
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ rBuilder is designed so agents answer **structural questions** from a pre-built 
 
 **Full JSON reference:** [docs/json-api.md](docs/json-api.md)  
 **Copy-paste recipes:** [docs/agent-recipes.md](docs/agent-recipes.md)
+**Skill bundles:** [SKILLS.md](SKILLS.md) — installable agent workflows (agentskills.io format)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Quick links into **[Introduction](docs/Introduction.md)** — see [Where most to
 | **[User Guide](docs/user-guide.md)** | Install, ecommerce-java fixture, every CLI command |
 | **[Dashboard user guide](docs/dashboard-user-guide.md)** | Browser UI tab-by-tab |
 | **[AGENTS.md](AGENTS.md)** | **LLM agents** — discover once, query JSON |
+| **[SKILLS.md](SKILLS.md)** | **LLM agents** — installable skill bundles (agentskills.io) |
 | **[Agent recipes](docs/agent-recipes.md)** | Copy-paste automation workflows |
 | **[JSON API](docs/json-api.md)** | Parse `-f json` payloads |
 | **[HTTP API](docs/http-api.md)** | `rbuilder serve` → `/api/query` and `/api/semantic/*` |

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,0 +1,102 @@
+# rBuilder Agent Skills
+
+Invocable skill bundles for AI coding agents — workflows they activate when a task matches, instead of reading static docs every turn.
+
+Skills follow the [agentskills.io](https://agentskills.io/specification) open standard and work across Claude Code, Cursor, OpenCode, Goose, and any compatible agent.
+
+---
+
+## Quick start
+
+1. **Install rBuilder** — [GitHub Releases](https://github.com/sshaaf/rBuilder/releases) or `cargo build --release`
+2. **Index your repo** — `rbuilder discover .`
+3. **Install skill bundles** for your agent runtime (see [Platform install](#platform-install) below)
+
+---
+
+## Skill index
+
+| Skill | When to use | Key commands |
+|-------|-------------|--------------|
+| [rbuilder-orient](skills/rbuilder-orient/SKILL.md) | Explore unfamiliar repo, understand structure | `discover`, `gql`, `metrics --pagerank`, `semantic query` |
+| [rbuilder-impact](skills/rbuilder-impact/SKILL.md) | Refactor, rename, delete — change impact analysis | `blast-radius`, `gql` caller queries |
+| [rbuilder-session](skills/rbuilder-session/SKILL.md) | Multiple queries in one task, HTTP session | `serve`, `/api/query`, `/api/semantic/query` |
+| [rbuilder-neighborhood](skills/rbuilder-neighborhood/SKILL.md) | Call chains, dependency graphs, export subgraphs | `gql` CALLS traversal, `export` |
+| [rbuilder-slice](skills/rbuilder-slice/SKILL.md) | Line-level data flow, variable tracking | `slice` with `--view text/cfg/pdg` |
+| [rbuilder-security](skills/rbuilder-security/SKILL.md) | Taint analysis, source-to-sink security flows | `slice --taint` |
+| [rbuilder-migration](skills/rbuilder-migration/SKILL.md) | Migration planning, batch refactor strategy | `discover --export-migration-hints` |
+| [rbuilder-ci-gate](skills/rbuilder-ci-gate/SKILL.md) | CI policy enforcement, blast radius limits | `check --policy-file` |
+
+---
+
+## Platform install
+
+### Claude Code
+
+Add to `.claude/settings.json` in your project root:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(rbuilder:*)"
+    ]
+  },
+  "skills": [
+    "skills/rbuilder-orient",
+    "skills/rbuilder-impact",
+    "skills/rbuilder-session",
+    "skills/rbuilder-neighborhood",
+    "skills/rbuilder-slice",
+    "skills/rbuilder-security",
+    "skills/rbuilder-migration",
+    "skills/rbuilder-ci-gate"
+  ]
+}
+```
+
+### Cursor
+
+Copy or symlink each skill directory into `.cursor/skills/`:
+
+```bash
+mkdir -p .cursor/skills
+for skill in skills/rbuilder-*/; do
+  ln -s "../../$skill" ".cursor/skills/$(basename $skill)"
+done
+```
+
+### OpenCode
+
+Copy or symlink each skill directory into `.opencode/skills/`:
+
+```bash
+mkdir -p .opencode/skills
+for skill in skills/rbuilder-*/; do
+  ln -s "../../$skill" ".opencode/skills/$(basename $skill)"
+done
+```
+
+### Goose
+
+Copy or symlink each skill directory into `.goose/skills/`:
+
+```bash
+mkdir -p .goose/skills
+for skill in skills/rbuilder-*/; do
+  ln -s "../../$skill" ".goose/skills/$(basename $skill)"
+done
+```
+
+### Generic fallback
+
+If your agent does not support skill bundles, paste `AGENTS.md` into your agent's system prompt and refer to `docs/agent-recipes.md` for copy-paste workflows.
+
+---
+
+## Further reading
+
+- [AGENTS.md](AGENTS.md) — universal agent rules (discover once, use `-f json`, parse stdout only)
+- [docs/agent-recipes.md](docs/agent-recipes.md) — 10 copy-paste agent recipes
+- [docs/json-api.md](docs/json-api.md) — full JSON schema reference for all commands
+- [docs/http-api.md](docs/http-api.md) — HTTP server API (`serve`)

--- a/skills/rbuilder-ci-gate/SKILL.md
+++ b/skills/rbuilder-ci-gate/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: rbuilder-ci-gate
+description: >-
+  Enforce blast radius policies in CI pipelines.
+  Use when the user asks about CI policy checks, merge gates,
+  blast radius limits, quality gates, or policy enforcement.
+  Activates on: CI check, policy enforcement, blast radius limit,
+  merge gate, quality gate, policy file, CI pipeline, build gate,
+  policy violation.
+compatibility: Requires rbuilder CLI (v0.4+). Run `rbuilder --version` to verify.
+metadata:
+  author: rbuilder
+  version: "1.0"
+---
+
+## Prerequisites
+
+- A `.rbuilder/` directory must exist in the repo root. If missing, run:
+  ```bash
+  rbuilder discover .
+  ```
+- A policy file must exist (JSON format). See [docs/policy-format.md](../../docs/policy-format.md).
+
+## Decision Tree
+
+| User intent | Command |
+|-------------|---------|
+| Check against policy | `rbuilder check --policy-file policy.json -f json` |
+| CI pipeline gate (exit code) | `rbuilder check --policy-file policy.json` (exit 0 = pass, exit 1 = violations) |
+
+> **Note:** There is no `-s` flag — `check` evaluates all git-changed functions against the policy.
+
+## Output Contract
+
+Always use `-f json`. Key fields:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `.passed` | bool | `true` if all checks pass |
+| `.policy` | string | Path to policy file used |
+| `.violations[]` | array | List of violations (empty when passed) |
+| `.violations[].symbol` | string | Function that violated the policy |
+| `.violations[].error` | string | Error details (if applicable) |
+| `.violations[].violation` | string | Which policy rule was violated |
+
+See [commands reference](references/commands.md) for full JSON shapes.
+
+## Stop Conditions
+
+Do **not** use this skill when:
+- **No policy file exists** — help the user create one first (see [docs/policy-format.md](../../docs/policy-format.md))
+- The user wants **exploratory analysis**, not CI enforcement → use **rbuilder-impact** instead
+- The user wants to **understand** impact before writing policies → use **rbuilder-impact** first
+
+## Failure Playbook
+
+| Symptom | Fix |
+|---------|-----|
+| `policy file not found` | Verify path to policy file |
+| All checks fail | Verify policy file is valid **JSON** (not YAML) |
+| Exit code 1 | Expected when violations are found — not an error |
+| `graph snapshot not found` | Run `rbuilder discover .` first |
+
+## Example Turn
+
+**User:** "Set up a CI gate that fails if any function has a blast radius over 50."
+
+**Agent:**
+1. Create `policy.json`:
+   ```json
+   {
+     "rules": [
+       { "metric": "impact_zone_size", "max": 50 }
+     ]
+   }
+   ```
+2. `rbuilder check --policy-file policy.json -f json`
+3. Parse `.passed` and `.violations[]`
+
+**Reply:** "Policy check found 2 violations: `OrderProcessor.validate` has an impact zone of 67 (limit 50) and `PaymentGateway.charge` has 53. These functions exceed the blast radius threshold. Exit code 1 blocks the CI pipeline."

--- a/skills/rbuilder-ci-gate/references/commands.md
+++ b/skills/rbuilder-ci-gate/references/commands.md
@@ -1,0 +1,55 @@
+# rbuilder-ci-gate Command Reference
+
+Detailed flag and JSON output reference for commands used by this skill.
+For full TypeScript interface definitions, see [docs/json-api.md](../../docs/json-api.md).
+For policy file format, see [docs/policy-format.md](../../docs/policy-format.md).
+
+## `check`
+
+```bash
+rbuilder check --policy-file policy.json -f json
+rbuilder check --policy-file policy.json
+```
+
+| Flag | Type | Required | Notes |
+|------|------|----------|-------|
+| `--policy-file` | string | **yes** | Path to policy JSON file |
+
+### JSON output (`schema_version: 1`)
+
+```json
+{
+  "schema_version": 1,
+  "policy": "policy.json",
+  "violations": [
+    {
+      "symbol": "OrderProcessor.validate",
+      "violation": "impact_zone_size 67 exceeds max 50"
+    },
+    {
+      "symbol": "PaymentGateway.charge",
+      "error": "impact_zone_size 53 exceeds max 50"
+    }
+  ],
+  "passed": false
+}
+```
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | All checks pass — no violations |
+| `1` | Policy violations found (or command error) |
+
+### CI integration
+
+```yaml
+# GitHub Actions example
+- name: rBuilder policy check
+  run: |
+    rbuilder discover .
+    rbuilder check --policy-file policy.json
+```
+
+The exit code `1` on violations automatically fails the CI step.

--- a/skills/rbuilder-ci-gate/references/commands.md
+++ b/skills/rbuilder-ci-gate/references/commands.md
@@ -28,7 +28,7 @@ rbuilder check --policy-file policy.json
     },
     {
       "symbol": "PaymentGateway.charge",
-      "error": "impact_zone_size 53 exceeds max 50"
+      "violation": "impact_zone_size 53 exceeds max 50"
     }
   ],
   "passed": false

--- a/skills/rbuilder-impact/SKILL.md
+++ b/skills/rbuilder-impact/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: rbuilder-impact
+description: >-
+  Analyze change impact before refactoring, renaming, or deleting symbols.
+  Use when the user asks about blast radius, who calls a function, whether
+  a change is safe, or what breaks if something is modified.
+  Activates on: refactor, rename, delete symbol, change impact, who calls this,
+  blast radius, safe to change, what depends on this, callers, impact analysis.
+compatibility: Requires rbuilder CLI (v0.4+). Run `rbuilder --version` to verify.
+metadata:
+  author: rbuilder
+  version: "1.0"
+---
+
+## Prerequisites
+
+- A `.rbuilder/` directory must exist in the repo root. If missing, run:
+  ```bash
+  rbuilder discover .
+  ```
+
+## Decision Tree
+
+| User intent | Command |
+|-------------|---------|
+| Impact of changing symbol X | `rbuilder blast-radius X -f json` |
+| Disambiguate symbol by class | `rbuilder blast-radius X --class MyClass -f json` |
+| Disambiguate symbol by file | `rbuilder blast-radius X --file src/path/File.java -f json` |
+| Limit impact depth to N hops | `rbuilder blast-radius X --depth N -f json` |
+| Who calls X (direct callers) | `rbuilder gql "MATCH (a:Function)-[:CALLS]->(b:Function) WHERE b.name = 'X' RETURN a" -f json` |
+| Full caller chain (up to 3 hops) | `rbuilder gql "MATCH (a:Function)-[:CALLS*1..3]->(b:Function) WHERE b.name = 'X' RETURN a,b" -f json` |
+
+## Output Contract
+
+Always use `-f json`. Key fields to surface:
+
+| Command | Key fields |
+|---------|-----------|
+| `blast-radius` | `.target` (symbol info), `.metrics.score`, `.metrics.direct_callers_count`, `.metrics.impact_zone_size`, `.topology.direct_callers[]`, `.topology.impact_zone[]`, `.gatekeeping.policy_status` |
+| `gql` | `.rows[]` — each row is an array of bindings with `.binding`, `.node`, `.type`, `.file` |
+
+See [commands reference](references/commands.md) for full JSON shapes.
+
+## Stop Conditions
+
+Do **not** use this skill when:
+- The user wants a **repo overview** → use **rbuilder-orient** instead
+- The user wants to trace **data flow within a function** → use **rbuilder-slice** instead
+- The user wants **taint/security analysis** → use **rbuilder-security** instead
+- The user wants to **export a subgraph** → use **rbuilder-neighborhood** instead
+
+## Failure Playbook
+
+| Symptom | Fix |
+|---------|-----|
+| `Multiple symbols match` | Add `--class ClassName` or `--file path/to/File.java` |
+| `Symbol not found` | Check spelling; use `rbuilder gql --macro-name all_functions unused -f json` to list available symbols |
+| Stale results after code changes | Re-run `rbuilder discover .` to rebuild the graph |
+| `.gatekeeping.violations` is non-empty | Policy violations found — review `.gatekeeping.violations[].violation` |
+
+## Example Turn
+
+**User:** "Is it safe to rename `OrderProcessor.validate`?"
+
+**Agent:**
+1. `rbuilder blast-radius OrderProcessor.validate -f json`
+2. Parse `.metrics.direct_callers_count` and `.metrics.impact_zone_size`
+3. Review `.topology.direct_callers[]` for affected symbols
+
+**Reply:** "Renaming `OrderProcessor.validate` affects 4 direct callers and 12 functions in the transitive impact zone. The direct callers are `CheckoutService.process`, `BatchRunner.run`, `ApiController.submit`, and `TestHelper.setup`. I'd recommend updating all 4 call sites in one PR."

--- a/skills/rbuilder-impact/references/commands.md
+++ b/skills/rbuilder-impact/references/commands.md
@@ -1,0 +1,65 @@
+# rbuilder-impact Command Reference
+
+Detailed flag and JSON output reference for commands used by this skill.
+For full TypeScript interface definitions, see [docs/json-api.md](../../docs/json-api.md).
+
+## `blast-radius`
+
+```bash
+rbuilder blast-radius SYMBOL -f json
+rbuilder blast-radius SYMBOL --class ClassName -f json
+rbuilder blast-radius SYMBOL --depth 3 -f json
+```
+
+| Flag | Type | Notes |
+|------|------|-------|
+| `SYMBOL` (positional) | string | **Required.** Function name, UUID, or FQN (`Class::method`) |
+| `--depth` | usize | Limit upstream impact to N call hops (default: full transitive closure) |
+| `--class` | string | Class/namespace filter for disambiguation |
+| `--file` | string | Source file path filter for disambiguation |
+| `--with-slices` | bool | Run statement-level slice hand-off analysis |
+| `--policy-file` | string | Path to policy JSON file |
+| `--no-policy` | bool | Skip policy evaluation |
+
+### JSON output (`schema_version: 2`)
+
+```json
+{
+  "schema_version": 2,
+  "target": {
+    "name": "validate",
+    "fqn": "OrderProcessor.validate",
+    "file": "src/order/processor.java",
+    "language": "java",
+    "canonical_fqn": "com.example.order.OrderProcessor.validate"
+  },
+  "metrics": {
+    "score": 0.73,
+    "direct_callers_count": 4,
+    "impact_zone_size": 12,
+    "caller_depth_limit": null
+  },
+  "topology": {
+    "scc_component_id": null,
+    "direct_callers": [
+      { "name": "CheckoutService.process", "file": "src/checkout/service.java" }
+    ],
+    "impact_zone": [
+      { "name": "ApiController.submit", "file": "src/api/controller.java" }
+    ]
+  },
+  "gatekeeping": {
+    "policy_status": "no_policy",
+    "violations": [],
+    "handoffs": []
+  }
+}
+```
+
+## `gql` (caller queries)
+
+```bash
+rbuilder gql "MATCH (a:Function)-[:CALLS]->(b:Function) WHERE b.name = 'X' RETURN a" -f json
+```
+
+See [rbuilder-orient commands reference](../rbuilder-orient/references/commands.md#gql) for full GQL flag and output documentation.

--- a/skills/rbuilder-migration/SKILL.md
+++ b/skills/rbuilder-migration/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: rbuilder-migration
+description: >-
+  Generate and inspect migration plans for large-scale refactors.
+  Use when the user asks about migration strategy, batch refactoring,
+  dependency-aware ordering, or upgrading a codebase systematically.
+  Activates on: migration plan, upgrade dependencies, batch refactor,
+  large-scale changes, migration strategy, modernization, rewrite plan,
+  migration order, dependency ordering.
+compatibility: Requires rbuilder CLI (v0.4+). Run `rbuilder --version` to verify.
+metadata:
+  author: rbuilder
+  version: "1.0"
+---
+
+## Prerequisites
+
+- Run a full discover with all analysis flags:
+  ```bash
+  rbuilder discover . --with-cfg --with-taint --with-security --with-dashboard --with-harmonic --export-migration-hints
+  ```
+- There is **no `--all` shorthand** — each `--with-*` flag must be passed individually.
+
+## Decision Tree
+
+| User intent | Command |
+|-------------|---------|
+| Generate migration plan | `rbuilder discover . --with-cfg --with-taint --with-security --with-dashboard --with-harmonic --export-migration-hints` |
+| Use foundational-first preset | Add `--migration-preset foundational_first` |
+| Use dense cluster preset | Add `--migration-preset dense_cluster` |
+| Use risk mitigation preset | Add `--migration-preset risk_mitigation` |
+| Priority ordering (score-only) | Add `--migration-order priority` |
+| Scheduled ordering (topological) | `--migration-order scheduled` (default) |
+| Inspect the plan | Read `.rbuilder/migration_plan.json` |
+| View in dashboard | `rbuilder serve --open` → Migration tab |
+
+### Migration presets
+
+| Preset | Strategy |
+|--------|----------|
+| `hybrid_default` | Balanced α·PageRank + β·Harmonic − γ·Blast |
+| `foundational_first` | Prioritize high-PageRank foundational packages |
+| `dense_cluster` | Extract dense community clusters first |
+| `risk_mitigation` | Minimize blast radius risk |
+
+## Output Contract
+
+The migration plan is written to `.rbuilder/migration_plan.json`. Key fields:
+
+| Field | Meaning |
+|-------|---------|
+| `packages[]` | Ordered list of packages to migrate |
+| `packages[].name` | Package name |
+| `packages[].priority_score` | Computed priority (higher = migrate first) |
+| `packages[].step` | Scheduled step number (topological order) |
+| `packages[].functions` | Functions in the package |
+
+See [commands reference](references/commands.md) for full JSON shapes.
+
+## Stop Conditions
+
+Do **not** use this skill when:
+- The user wants to change a **single symbol** → use **rbuilder-impact** instead
+- No actual migration is planned — use other skills for exploratory analysis
+- The user wants **CI enforcement** → use **rbuilder-ci-gate** instead
+
+## Failure Playbook
+
+| Symptom | Fix |
+|---------|-----|
+| Empty migration plan | Ensure all `--with-*` flags are passed (especially `--with-harmonic`) |
+| Missing packages | Re-run `discover` with all flags — partial indexing produces partial plans |
+| Plan has wrong ordering | Try a different `--migration-preset` or `--migration-order` |
+
+## Example Turn
+
+**User:** "Create a migration plan prioritizing foundational packages."
+
+**Agent:**
+1. `rbuilder discover . --with-cfg --with-taint --with-security --with-dashboard --with-harmonic --export-migration-hints --migration-preset foundational_first`
+2. Read `.rbuilder/migration_plan.json` and parse `packages[:5]`
+
+**Reply:** "Migration plan generated with foundational-first ordering. Top 5 packages to migrate: `core.utils` (score 0.89), `data.models` (0.82), `auth.service` (0.74), `api.gateway` (0.68), `order.processing` (0.61). The plan has 12 packages across 8 scheduled steps."

--- a/skills/rbuilder-migration/references/commands.md
+++ b/skills/rbuilder-migration/references/commands.md
@@ -1,0 +1,42 @@
+# rbuilder-migration Command Reference
+
+Detailed flag and JSON output reference for commands used by this skill.
+For full documentation, see [docs/json-api.md](../../docs/json-api.md) §12 and [building-migration-plan.md](../../docs/building-migration-plan.md).
+
+## `discover` (migration mode)
+
+```bash
+rbuilder discover . \
+  --with-cfg --with-taint --with-security \
+  --with-dashboard --with-harmonic \
+  --export-migration-hints \
+  --migration-preset foundational_first \
+  --migration-order priority
+```
+
+### Migration-specific flags
+
+| Flag | Type | Default | Notes |
+|------|------|---------|-------|
+| `--export-migration-hints` | bool | false | Write migration plan JSON. Alias: `--export-migration-plan` (deprecated) |
+| `--migration-preset` | enum | `hybrid_default` | `hybrid_default`, `foundational_first`, `dense_cluster`, `risk_mitigation` |
+| `--migration-order` | enum | `scheduled` | `scheduled` (topological) or `priority` (score-only) |
+| `--with-harmonic` | bool | false | Compute harmonic centrality (used in priority scoring) |
+
+### All `--with-*` flags (required for full migration)
+
+| Flag | Purpose |
+|------|---------|
+| `--with-cfg` | Per-function CFG, dominators, PDG |
+| `--with-taint` | Discover-time taint analysis |
+| `--with-security` | Secret scanning |
+| `--with-dashboard` | Static dashboard bundle export |
+| `--with-harmonic` | Harmonic centrality for migration scoring |
+
+### Output file
+
+Default path: `.rbuilder/migration_plan.json`
+
+Override with `-o /custom/path.json`.
+
+The dashboard copy is at `.rbuilder/dashboard/migration_plan.json` (when `--with-dashboard` is set).

--- a/skills/rbuilder-neighborhood/SKILL.md
+++ b/skills/rbuilder-neighborhood/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: rbuilder-neighborhood
+description: >-
+  Explore call chains, dependency graphs, and function relationships.
+  Export subgraphs to Mermaid, GraphML, or Graphviz.
+  Use when the user asks about call chains, what calls what, function
+  dependencies, or needs to export a subgraph for visualization.
+  Activates on: call chain, dependency graph, what calls what, function
+  relationships, export subgraph, visualize dependencies, call tree.
+compatibility: Requires rbuilder CLI (v0.4+). Run `rbuilder --version` to verify.
+metadata:
+  author: rbuilder
+  version: "1.0"
+---
+
+## Prerequisites
+
+- A `.rbuilder/` directory must exist in the repo root. If missing, run:
+  ```bash
+  rbuilder discover .
+  ```
+
+## Decision Tree
+
+| User intent | Command |
+|-------------|---------|
+| Direct callees of X | `rbuilder gql "MATCH (a:Function)-[:CALLS]->(b:Function) WHERE a.name = 'X' RETURN a,b" -f json` |
+| Direct callers of X | `rbuilder gql "MATCH (a:Function)-[:CALLS]->(b:Function) WHERE b.name = 'X' RETURN a,b" -f json` |
+| N-hop call neighborhood | `rbuilder gql "MATCH (a:Function)-[:CALLS*1..N]->(b:Function) WHERE a.name = 'X' RETURN a,b LIMIT 50" -f json` |
+| Built-in call chain macro | `rbuilder gql --macro-name call_chain unused -f json` |
+| Export as Mermaid | `rbuilder export --export-format mermaid --export-output graph.mmd --query "name:X"` |
+| Export as GraphML | `rbuilder export --export-format graphml --export-output graph.graphml --query all` |
+| Export as Graphviz | `rbuilder export --export-format graphviz --export-output graph.dot --query "type:Function"` |
+| Export as JSON | `rbuilder export --export-format json --export-output graph.json --query functions` |
+
+> **Note:** `export --query` uses **filter syntax** (`all`, `name:Foo`, `type:Function`, `functions`, `classes`, compound `|`), **not** GQL MATCH syntax. The `name:` filter uses exact match.
+
+## Output Contract
+
+Always use `-f json` for `gql`. Export writes directly to the file specified by `--export-output`.
+
+| Command | Key fields |
+|---------|-----------|
+| `gql` | `.rows[]` — each row is an array of bindings with `.binding`, `.node`, `.type`, `.file` |
+| `export` | Writes to `--export-output` file in the specified format |
+
+See [commands reference](references/commands.md) for full details.
+
+## Stop Conditions
+
+Do **not** use this skill when:
+- The user needs a **full repo overview** → use **rbuilder-orient** instead
+- The user needs **change impact analysis** → use **rbuilder-impact** instead (blast-radius gives richer impact data than raw call chains)
+- The user needs **data flow** within a function → use **rbuilder-slice** instead
+
+## Failure Playbook
+
+| Symptom | Fix |
+|---------|-----|
+| Too many results | Add `LIMIT N` to GQL queries |
+| `Symbol not found` | Check spelling with `rbuilder gql --macro-name all_functions unused -f json` |
+| Export produces empty file | Check `--query` filter — `name:X` uses exact match; try `all` or `functions` |
+| `--query` syntax error | Export uses filter syntax, not GQL MATCH. Use `all`, `name:Foo`, `type:Function`, `functions`, `classes`, or compound with `\|` |
+
+## Example Turn
+
+**User:** "Show me what `PaymentGateway.charge` calls and export a Mermaid diagram."
+
+**Agent:**
+1. `rbuilder gql "MATCH (a:Function)-[:CALLS]->(b:Function) WHERE a.name = 'charge' RETURN a,b" -f json | jq '.rows | length'`
+2. `rbuilder export --export-format mermaid --export-output charge_calls.mmd --query "name:charge"`
+
+**Reply:** "`PaymentGateway.charge` calls 3 functions. Mermaid diagram exported to `charge_calls.mmd` — you can paste it into any Mermaid renderer."

--- a/skills/rbuilder-neighborhood/references/commands.md
+++ b/skills/rbuilder-neighborhood/references/commands.md
@@ -1,0 +1,49 @@
+# rbuilder-neighborhood Command Reference
+
+Detailed flag and JSON output reference for commands used by this skill.
+For full TypeScript interface definitions, see [docs/json-api.md](../../docs/json-api.md).
+
+## `gql` (call chain queries)
+
+See [rbuilder-orient commands reference](../rbuilder-orient/references/commands.md#gql) for full GQL documentation.
+
+### Common call chain patterns
+
+```bash
+# Direct calls from X
+rbuilder gql "MATCH (a:Function)-[:CALLS]->(b:Function) WHERE a.name = 'X' RETURN a,b" -f json
+
+# Direct callers of X
+rbuilder gql "MATCH (a:Function)-[:CALLS]->(b:Function) WHERE b.name = 'X' RETURN a,b" -f json
+
+# 3-hop transitive callees
+rbuilder gql "MATCH (a:Function)-[:CALLS*1..3]->(b:Function) WHERE a.name = 'X' RETURN a,b LIMIT 50" -f json
+
+# All direct calls (built-in macro)
+rbuilder gql --macro-name direct_calls unused -f json
+```
+
+## `export`
+
+```bash
+rbuilder export --export-format mermaid --export-output graph.mmd --query "name:X"
+```
+
+| Flag | Type | Notes |
+|------|------|-------|
+| `--export-format` | enum | **Required.** `json`, `graphml`, `graphviz`, `mermaid` |
+| `--export-output` | string | **Required.** Output file path |
+| `--query` | string | Filter: `all` (default), `name:Foo`, `type:Function`, `functions`, `classes`, `structs`, `files`, `config`, `name_suffix:X`, `signature:*pattern*`, compound with `\|` |
+
+### Filter syntax (not GQL)
+
+| Filter | Meaning |
+|--------|---------|
+| `all` | All nodes |
+| `name:main` | Exact name match |
+| `type:Function` | By node type (case-insensitive) |
+| `functions` | Shorthand for `type:Function` |
+| `classes` | Shorthand for `type:Class` |
+| `name_suffix:Service` | Name ends with |
+| `signature:*pattern*` | Signature wildcard match |
+| `type:Function\|name_suffix:Service` | Compound intersection (pipe) |

--- a/skills/rbuilder-orient/SKILL.md
+++ b/skills/rbuilder-orient/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: rbuilder-orient
+description: >-
+  Explore an unfamiliar repository using rBuilder's code knowledge graph.
+  Use when the user asks to understand codebase structure, find important
+  functions, get a repo overview, or explore what a project does.
+  Activates on: unfamiliar repo, explore structure, understand codebase,
+  what does this project do, find important functions, repo overview,
+  codebase map, architecture overview.
+compatibility: Requires rbuilder CLI (v0.4+). Run `rbuilder --version` to verify.
+metadata:
+  author: rbuilder
+  version: "1.0"
+---
+
+## Prerequisites
+
+- A `.rbuilder/` directory must exist in the repo root. If missing, run:
+  ```bash
+  rbuilder discover .
+  ```
+- For natural-language search, run `rbuilder semantic index` separately after discover — it is a distinct indexing step that builds the embedding index.
+
+## Decision Tree
+
+| User intent | Command |
+|-------------|---------|
+| Repo overview (files, nodes, edges) | `rbuilder discover -f json` |
+| Key functions by importance | `rbuilder metrics --pagerank -f json` |
+| List all functions | `rbuilder gql --macro-name all_functions unused -f json` |
+| Call graph overview | `rbuilder gql --macro-name call_chain unused -f json` |
+| Find functions by name pattern | `rbuilder gql "MATCH (n:Function) WHERE n.name LIKE '*Handler' RETURN n LIMIT 20" -f json` |
+| Natural-language search | `rbuilder semantic query "authentication logic" -f json` |
+
+> **Note:** `--macro-name` requires a positional query argument even though it is ignored. Pass `unused` as a placeholder.
+
+## Output Contract
+
+Always use `-f json`. Key fields to surface:
+
+| Command | Key fields |
+|---------|-----------|
+| `discover` | `.metrics.files_discovered`, `.metrics.files_indexed`, `.metrics.nodes_generated`, `.metrics.edges_generated`, `.metrics.duration_ms` |
+| `metrics --pagerank` | `.pagerank.top[]` — each entry has `.node` (UUID) and `.pagerank` (score). Report top 10. |
+| `gql` | `.rows[]` — each row is an array of bindings with `.binding`, `.node`, `.type`, `.file` |
+| `semantic query` | `.hits[]` — each hit has function name, file, and relevance score |
+
+See [commands reference](references/commands.md) for full JSON shapes.
+
+## Stop Conditions
+
+Do **not** use this skill when:
+- The user already knows the repo structure and is asking about a **specific symbol** → use **rbuilder-impact** instead
+- The user wants to understand **data flow within a function** → use **rbuilder-slice** instead
+- The user wants **change impact analysis** before editing → use **rbuilder-impact** instead
+
+## Failure Playbook
+
+| Symptom | Fix |
+|---------|-----|
+| `Error: graph snapshot not found` | Run `rbuilder discover .` first |
+| `query macro not found` | Check macro name — available macros: `all_functions`, `direct_calls`, `call_chain` |
+| `semantic index not found` | Run `rbuilder semantic index` (separate step from discover) |
+| Too many results | Add `LIMIT N` to GQL queries |
+
+## Example Turn
+
+**User:** "I just cloned this repo. What's the architecture?"
+
+**Agent:**
+1. `rbuilder discover . -f json` → get file/node/edge counts
+2. `rbuilder metrics --pagerank -f json | jq '.pagerank.top[:10]'` → find architectural hotspots
+3. `rbuilder gql --macro-name all_functions unused -f json | jq '.count'` → total function count
+
+**Reply:** "This repo has 342 files with 1,847 functions and 5,203 call edges. The top PageRank functions are `ShoppingCartService.checkout` (0.034), `OrderProcessor.validate` (0.028), and `PaymentGateway.charge` (0.025) — these are the architectural hotspots."

--- a/skills/rbuilder-orient/references/commands.md
+++ b/skills/rbuilder-orient/references/commands.md
@@ -1,0 +1,127 @@
+# rbuilder-orient Command Reference
+
+Detailed flag and JSON output reference for commands used by this skill.
+For full TypeScript interface definitions, see [docs/json-api.md](../../docs/json-api.md).
+
+## `discover`
+
+```bash
+rbuilder discover [PATH] -f json
+```
+
+| Flag | Type | Default | Notes |
+|------|------|---------|-------|
+| `PATH` (positional) | string | cwd | Repository path |
+| `--languages` / `-l` | string | all | Language filter |
+| `--exclude` / `-e` | string | none | Exclude patterns |
+| `-f json` | global | text | Output format |
+
+### JSON output (`schema_version: 2`)
+
+```json
+{
+  "schema_version": 2,
+  "command": "discover",
+  "metrics": {
+    "files_discovered": 342,
+    "files_indexed": 310,
+    "files_skipped": 32,
+    "nodes_generated": 1847,
+    "edges_generated": 5203,
+    "duration_ms": 1523
+  }
+}
+```
+
+## `metrics`
+
+```bash
+rbuilder metrics [--pagerank] [--betweenness] [--communities] -f json
+```
+
+When no section flag is passed, all three sections are included.
+
+| Flag | Type | Notes |
+|------|------|-------|
+| `--pagerank` | bool | Include PageRank section |
+| `--betweenness` | bool | Include betweenness section |
+| `--communities` | bool | Include communities section |
+| `--iterations` | usize | PageRank iteration count |
+
+### JSON output (`schema_version: 1`)
+
+```json
+{
+  "schema_version": 1,
+  "pagerank": {
+    "top": [
+      { "node": "<uuid>", "pagerank": 0.034 }
+    ],
+    "converged": true,
+    "iterations": 100,
+    "max_delta": 0.0001
+  },
+  "betweenness": [
+    { "node": "<uuid>", "score": 0.15 }
+  ],
+  "communities": {
+    "count": 12,
+    "modularity": 0.45,
+    "assignments": 1847
+  }
+}
+```
+
+## `gql`
+
+```bash
+rbuilder gql "MATCH (n:Function) RETURN n LIMIT 20" -f json
+rbuilder gql --macro-name all_functions unused -f json
+```
+
+| Flag | Type | Notes |
+|------|------|-------|
+| `query` (positional) | string | **Required.** GQL MATCH query (or `unused` with `--macro-name`) |
+| `--macro-name` | string | Use built-in macro: `all_functions`, `direct_calls`, `call_chain` |
+| `--explain` | bool | Show query plan |
+
+### GQL syntax
+
+```
+MATCH (n:Function) RETURN n
+MATCH (n:Function) WHERE n.name LIKE '*Service*' RETURN n LIMIT 20
+MATCH (n:Function) WHERE n.name = 'main' RETURN n
+MATCH (a:Function)-[:CALLS*1..3]->(b:Function) RETURN a,b LIMIT 50
+```
+
+Operators: `=` (exact), `LIKE` (glob with `*`), `AND` for combining predicates.
+
+### JSON output (`schema_version: 1`)
+
+```json
+{
+  "schema_version": 1,
+  "rows": [
+    [
+      { "binding": "n", "node": "ShoppingCartService.checkout", "type": "Function", "file": "src/cart/service.java" }
+    ]
+  ],
+  "count": 1,
+  "explain": false
+}
+```
+
+## `semantic query`
+
+```bash
+rbuilder semantic query "authentication logic" -f json --limit 10
+```
+
+| Flag | Type | Default | Notes |
+|------|------|---------|-------|
+| `TEXT` (positional) | string | — | Natural-language or keyword query |
+| `--limit` | usize | 20 | Max hits |
+| `--expand` | enum | none | `neighbors`, `blast`, `gql`, `all` |
+| `--no-fusion` | bool | false | Disable late fusion re-ranking |
+
+Requires `rbuilder semantic index` to have been run first.

--- a/skills/rbuilder-security/SKILL.md
+++ b/skills/rbuilder-security/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: rbuilder-security
+description: >-
+  Run taint analysis to trace untrusted input from source to sink.
+  Use when the user asks about security flows, injection risks,
+  taint analysis, data sanitization, or source-to-sink tracking.
+  Activates on: taint analysis, security flow, untrusted input,
+  source to sink, injection risk, data sanitization, SQL injection,
+  XSS, command injection, taint trace.
+compatibility: Requires rbuilder CLI (v0.4+) with `discover --with-cfg --with-taint` indexing.
+metadata:
+  author: rbuilder
+  version: "1.0"
+---
+
+## Prerequisites
+
+- A `.rbuilder/` directory must exist with CFG and taint data. Run:
+  ```bash
+  rbuilder discover . --with-cfg --with-taint
+  ```
+- Both `--with-cfg` and `--with-taint` are required. Without them, taint returns no results.
+
+## Decision Tree
+
+| User intent | Command |
+|-------------|---------|
+| Taint trace from a variable | `rbuilder slice src/path/File.java --line 42 --variable userInput --taint -f json` |
+| Taint with function context | Add `--function processRequest` |
+| View taint as CFG | Add `--view cfg` |
+
+> **Note:** There is no `--sink` filter flag. Taint analysis runs against all detected source-to-sink patterns.
+
+## Output Contract
+
+Always use `-f json`. Key fields:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `.taint` | bool | Whether taint was detected |
+| `.flows` | number | Total taint flow count |
+| `.vulnerable` | number | Number of vulnerable flows |
+| `.file` | string | Source file path |
+| `.function` | string | Enclosing function |
+| `.line` | number | Criterion line |
+| `.variable` | string | Criterion variable |
+
+See [commands reference](references/commands.md) for full JSON shapes.
+
+## Stop Conditions
+
+Do **not** use this skill when:
+- The question is **not security-related** → use **rbuilder-slice** for general data flow
+- The user needs **call-level impact** → use **rbuilder-impact** instead
+- The user wants a **repo overview** → use **rbuilder-orient** instead
+
+## Failure Playbook
+
+| Symptom | Fix |
+|---------|-----|
+| No taint results | Ensure `discover --with-cfg --with-taint` was run |
+| `variable not found at line` | Verify the variable name exists at the specified line |
+| False positive taint | Review the flow path — rBuilder detects patterns, not semantic intent |
+| Three args required error | `slice` always needs: positional file, `--line`, `--variable` |
+
+## Example Turn
+
+**User:** "Is the `userInput` parameter at line 10 of `LoginController.java` vulnerable to SQL injection?"
+
+**Agent:**
+1. `rbuilder slice src/auth/LoginController.java --line 10 --variable userInput --function authenticate --taint -f json`
+2. Parse `.taint`, `.flows`, `.vulnerable`
+
+**Reply:** "Taint analysis found 2 flows from `userInput` at line 10, with 1 vulnerable path reaching `jdbcTemplate.query()` at line 34 without sanitization. The variable passes through `buildQuery()` at line 22 which concatenates it directly into SQL."

--- a/skills/rbuilder-security/references/commands.md
+++ b/skills/rbuilder-security/references/commands.md
@@ -1,0 +1,41 @@
+# rbuilder-security Command Reference
+
+Detailed flag and JSON output reference for commands used by this skill.
+For full TypeScript interface definitions, see [docs/json-api.md](../../docs/json-api.md).
+
+## `slice --taint`
+
+```bash
+rbuilder slice FILE --line N --variable VAR --taint -f json
+rbuilder slice FILE --line N --variable VAR --function FUNC --taint -f json
+rbuilder slice FILE --line N --variable VAR --taint --view cfg -f json
+```
+
+All flags from `slice` apply (see [rbuilder-slice commands reference](../rbuilder-slice/references/commands.md)). The `--taint` flag switches from program slicing to taint analysis mode.
+
+### JSON output — taint mode (`schema_version: 1`)
+
+```json
+{
+  "schema_version": 1,
+  "file": "src/auth/LoginController.java",
+  "function": "authenticate",
+  "line": 10,
+  "variable": "userInput",
+  "taint": true,
+  "flows": 2,
+  "vulnerable": 1
+}
+```
+
+### Indexing requirements
+
+Taint analysis requires two discover flags:
+- `--with-cfg` — builds per-function control flow graphs
+- `--with-taint` — runs discover-time taint pattern detection
+
+```bash
+rbuilder discover . --with-cfg --with-taint
+```
+
+Without `--with-taint`, the `--taint` flag on `slice` returns zero flows.

--- a/skills/rbuilder-session/SKILL.md
+++ b/skills/rbuilder-session/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: rbuilder-session
+description: >-
+  Run multiple rBuilder queries in one task using the HTTP server.
+  Use when the user needs interactive exploration, batch analysis,
+  repeated queries, or the visual dashboard.
+  Activates on: multiple queries, interactive exploration, keep querying,
+  batch analysis, HTTP session, dashboard, start server, many queries.
+compatibility: Requires rbuilder CLI (v0.4+). Run `rbuilder --version` to verify.
+metadata:
+  author: rbuilder
+  version: "1.0"
+---
+
+## Prerequisites
+
+- A `.rbuilder/` directory must exist in the repo root. If missing, run:
+  ```bash
+  rbuilder discover .
+  ```
+- For semantic search via HTTP, run `rbuilder semantic index` first.
+
+## Decision Tree
+
+| User intent | Command |
+|-------------|---------|
+| Start HTTP server | `rbuilder serve --port 8080` |
+| Start query-only (no dashboard) | `rbuilder serve --port 8080 --query-only` |
+| Open dashboard in browser | `rbuilder serve --port 8080 --open` |
+| Graph query via HTTP | `curl -X POST http://127.0.0.1:8080/api/query -H 'Content-Type: application/json' -d '{"query": "MATCH (n:Function) RETURN n LIMIT 5"}'` |
+| Run macro via HTTP | `curl -X POST http://127.0.0.1:8080/api/query -H 'Content-Type: application/json' -d '{"macro": "all_functions"}'` |
+| Semantic search via HTTP | `curl -X POST http://127.0.0.1:8080/api/semantic/query -H 'Content-Type: application/json' -d '{"query": "checkout flow"}'` |
+| Check semantic index status | `curl http://127.0.0.1:8080/api/semantic/status` |
+| Health check | `curl http://127.0.0.1:8080/api/health` |
+
+## Output Contract
+
+HTTP responses return the same JSON shapes as CLI commands:
+
+| Endpoint | Method | Request body | Response |
+|----------|--------|-------------|----------|
+| `/api/query` | POST | `{"query": "..."}` or `{"macro": "..."}` or `{"query": "...", "explain": true}` | Same as `gql -f json` |
+| `/graphql` | POST | Same as `/api/query` (alias) | Same as `gql -f json` |
+| `/api/semantic/query` | POST | `{"query": "...", "limit": 20}` | Same as `semantic query -f json` |
+| `/api/semantic/status` | GET | — | `{"available": true/false, "model_id": "...", "dimensions": 256, "functions_indexed": N}` |
+| `/api/health` | GET | — | Health status |
+
+See [commands reference](references/commands.md) for full details.
+
+## Stop Conditions
+
+Do **not** use this skill when:
+- The user needs a **single one-off query** → use the CLI directly (rbuilder-orient, rbuilder-impact, etc.)
+- The user does not need a **persistent session** → other skills are simpler
+
+## Failure Playbook
+
+| Symptom | Fix |
+|---------|-----|
+| `Address already in use` | Try a different port: `--port 8081` |
+| Server won't start | Check that `.rbuilder/` exists (run `discover` first) |
+| Semantic endpoint returns `available: false` | Run `rbuilder semantic index` then restart `serve` |
+| `--daemon` conflicts error | `--daemon` is legacy and conflicts with `--port`/`--open` — use `serve` without `--daemon` |
+
+## Example Turn
+
+**User:** "I need to run several queries to understand this codebase."
+
+**Agent:**
+1. `rbuilder serve --port 8080 --query-only &` (start in background)
+2. `curl -s -X POST http://127.0.0.1:8080/api/query -H 'Content-Type: application/json' -d '{"macro": "all_functions"}' | jq '.count'`
+3. `curl -s -X POST http://127.0.0.1:8080/api/query -H 'Content-Type: application/json' -d '{"query": "MATCH (a:Function)-[:CALLS]->(b:Function) WHERE a.name = 'main' RETURN a,b"}' | jq '.rows | length'`
+
+**Reply:** "I started the query server. The repo has 1,847 functions. `main` directly calls 12 other functions. Let me drill into the hotspots next."

--- a/skills/rbuilder-session/SKILL.md
+++ b/skills/rbuilder-session/SKILL.md
@@ -69,6 +69,6 @@ Do **not** use this skill when:
 **Agent:**
 1. `rbuilder serve --port 8080 --query-only &` (start in background)
 2. `curl -s -X POST http://127.0.0.1:8080/api/query -H 'Content-Type: application/json' -d '{"macro": "all_functions"}' | jq '.count'`
-3. `curl -s -X POST http://127.0.0.1:8080/api/query -H 'Content-Type: application/json' -d '{"query": "MATCH (a:Function)-[:CALLS]->(b:Function) WHERE a.name = 'main' RETURN a,b"}' | jq '.rows | length'`
+3. `curl -s -X POST http://127.0.0.1:8080/api/query -H 'Content-Type: application/json' -d '{"query": "MATCH (a:Function)-[:CALLS]->(b:Function) WHERE a.name = '"'"'main'"'"' RETURN a,b"}' | jq '.rows | length'`
 
 **Reply:** "I started the query server. The repo has 1,847 functions. `main` directly calls 12 other functions. Let me drill into the hotspots next."

--- a/skills/rbuilder-session/references/commands.md
+++ b/skills/rbuilder-session/references/commands.md
@@ -1,0 +1,83 @@
+# rbuilder-session Command Reference
+
+Detailed flag and JSON output reference for commands used by this skill.
+For full HTTP API docs, see [docs/http-api.md](../../docs/http-api.md).
+
+## `serve`
+
+```bash
+rbuilder serve --port 8080
+rbuilder serve --port 8080 --query-only
+rbuilder serve --port 8080 --open
+```
+
+| Flag | Type | Default | Notes |
+|------|------|---------|-------|
+| `--host` | string | `127.0.0.1` | Bind host |
+| `--port` | u16 | 8080 | HTTP port |
+| `--open` | bool | false | Open dashboard in browser |
+| `--query-only` | bool | false | Serve query API only (no dashboard) |
+| `--dashboard-only` | bool | false | Serve dashboard only (no query API) |
+| `--dashboard-dir` | path | `.rbuilder/dashboard` | Dashboard directory |
+| `--daemon` | bool | false | Legacy socket daemon mode (conflicts with `--host`, `--port`, `--open`, `--query-only`, `--dashboard-only`, `--dashboard-dir`) |
+
+## HTTP endpoints
+
+### `POST /api/query`
+
+Request body:
+```json
+{"query": "MATCH (n:Function) RETURN n LIMIT 5"}
+```
+or:
+```json
+{"macro": "all_functions"}
+```
+or:
+```json
+{"query": "MATCH (n:Function) RETURN n", "explain": true}
+```
+
+All three fields are optional but at least `query` or `macro` must be provided (returns HTTP 400 otherwise).
+
+Response: same as `gql -f json`.
+
+### `POST /graphql`
+
+Alias for `/api/query`. Same request/response.
+
+### `POST /api/semantic/query`
+
+Request body:
+```json
+{
+  "query": "checkout flow",
+  "limit": 20,
+  "fusion": true,
+  "candidate_pool": 256,
+  "keyword_and": false,
+  "expand": "neighbors",
+  "expand_depth": 1
+}
+```
+
+Only `query` is required. All other fields have defaults.
+
+### `GET /api/semantic/status`
+
+Response:
+```json
+{
+  "available": true,
+  "model_id": "code-daemon",
+  "dimensions": 256,
+  "functions_indexed": 1847,
+  "graph_digest": "abc123..."
+}
+```
+
+When unavailable: `{"available": false, "message": "Semantic index not found ..."}`.
+
+### `GET /api/health`
+
+Returns health status.

--- a/skills/rbuilder-slice/SKILL.md
+++ b/skills/rbuilder-slice/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: rbuilder-slice
+description: >-
+  Trace data flow at the line level using program slicing.
+  Use when the user asks where a variable flows, what affects a line,
+  backward or forward slicing, or line-level data dependency analysis.
+  Activates on: data flow, variable tracking, where does this value go,
+  backward slice, forward slice, line-level analysis, what affects this line,
+  program slice, data dependency.
+compatibility: Requires rbuilder CLI (v0.4+) with `discover --with-cfg` indexing.
+metadata:
+  author: rbuilder
+  version: "1.0"
+---
+
+## Prerequisites
+
+- A `.rbuilder/` directory must exist with CFG data. Run:
+  ```bash
+  rbuilder discover . --with-cfg
+  ```
+- The `--with-cfg` flag is required for slice to work. Without it, slice returns empty results.
+
+## Decision Tree
+
+| User intent | Command |
+|-------------|---------|
+| Where does variable flow (forward) | `rbuilder slice src/path/File.java --line 42 --variable request --direction forward -f json` |
+| What affects this variable (backward) | `rbuilder slice src/path/File.java --line 42 --variable request -f json` |
+| Disambiguate by function name | Add `--function handleRequest` |
+| View as control flow graph | Add `--view cfg` |
+| View as program dependence graph | Add `--view pdg` |
+
+> **Three arguments are always required:** positional file path, `--line`, and `--variable`. The `--direction` defaults to `backward`.
+
+## Output Contract
+
+Always use `-f json`. Response shape depends on `--view`:
+
+| View | Key fields |
+|------|-----------|
+| `text` (default) | `.criterion` (line, variable), `.direction`, `.reduction_percent`, `.lines[]`, `.nodes[]`, `.edges[]` |
+| `cfg` | `.nodes[]` (CfgBlockNode — id, label, lines), `.edges[]` (CfgEdge — from, to, label) |
+| `pdg` | `.nodes[]` (PdgGraphNode — id, label, lines), `.edges[]` (PdgGraphEdge — from, to, kind) |
+
+See [commands reference](references/commands.md) for full JSON shapes.
+
+## Stop Conditions
+
+Do **not** use this skill when:
+- The user asks about **callers** of a function → use **rbuilder-impact** instead (blast-radius for impact, gql for call chains)
+- The user needs **taint/security analysis** → use **rbuilder-security** instead
+- The user wants a **call chain** → use **rbuilder-neighborhood** instead
+
+## Failure Playbook
+
+| Symptom | Fix |
+|---------|-----|
+| Empty slice result | Ensure `discover --with-cfg` was run (CFG data required) |
+| `variable not found at line` | Verify the variable name exists at the specified line in the source file |
+| Wrong function matched | Add `--function functionName` to disambiguate |
+| `file not found` | Use the path relative to the repo root |
+
+## Example Turn
+
+**User:** "Where does the `request` variable flow in `handleOrder` at line 15?"
+
+**Agent:**
+1. `rbuilder slice src/order/handler.java --line 15 --variable request --function handleOrder --direction forward -f json`
+2. Parse `.lines[]` for affected line numbers and `.reduction_percent` for scope
+
+**Reply:** "The `request` variable at line 15 flows forward to 8 statements (lines 15, 18, 22, 25, 31, 38, 42, 47) — a 73% slice reduction. It reaches the database call at line 42 via `repository.save(request.getOrder())`."

--- a/skills/rbuilder-slice/references/commands.md
+++ b/skills/rbuilder-slice/references/commands.md
@@ -1,0 +1,76 @@
+# rbuilder-slice Command Reference
+
+Detailed flag and JSON output reference for commands used by this skill.
+For full TypeScript interface definitions, see [docs/json-api.md](../../docs/json-api.md).
+
+## `slice`
+
+```bash
+rbuilder slice FILE --line N --variable VAR -f json
+rbuilder slice FILE --line N --variable VAR --direction forward -f json
+rbuilder slice FILE --line N --variable VAR --function FUNC --view cfg -f json
+```
+
+| Flag | Type | Required | Default | Notes |
+|------|------|----------|---------|-------|
+| `FILE` (positional) | string | **yes** | — | Source file path (relative to repo root) |
+| `--line` | usize | **yes** | — | Source line number |
+| `--variable` | string | **yes** | — | Variable name at the criterion |
+| `--function` | string | no | — | Enclosing function name (for disambiguation) |
+| `--language` | string | no | — | Language hint |
+| `--direction` | enum | no | `backward` | `backward` or `forward` |
+| `--taint` | bool | no | false | Run taint trace instead of slice (see rbuilder-security) |
+| `--view` | enum | no | `text` | `text`, `cfg`, or `pdg` |
+
+### JSON output — `--view text` (`schema_version: 1`)
+
+```json
+{
+  "schema_version": 1,
+  "file": "src/order/handler.java",
+  "criterion": { "line": 15, "variable": "request" },
+  "direction": "forward",
+  "reduction_percent": 73.2,
+  "lines": [15, 18, 22, 25, 31, 38, 42, 47],
+  "nodes": [
+    { "id": 0, "label": "request = ctx.getRequest()", "lines": [15] }
+  ],
+  "edges": [
+    { "from": 0, "to": 1, "kind": "data" }
+  ]
+}
+```
+
+### JSON output — `--view cfg`
+
+```json
+{
+  "schema_version": 1,
+  "file": "src/order/handler.java",
+  "function": "handleOrder",
+  "view": "cfg",
+  "nodes": [
+    { "id": 0, "label": "entry", "lines": [14, 15] }
+  ],
+  "edges": [
+    { "from": 0, "to": 1, "label": "true" }
+  ]
+}
+```
+
+### JSON output — `--view pdg`
+
+```json
+{
+  "schema_version": 1,
+  "file": "src/order/handler.java",
+  "function": "handleOrder",
+  "view": "pdg",
+  "nodes": [
+    { "id": 0, "label": "request = ctx.getRequest()", "lines": [15] }
+  ],
+  "edges": [
+    { "from": 0, "to": 1, "kind": "data" }
+  ]
+}
+```


### PR DESCRIPTION
## Description

  Add 8 agent skill bundles following the agentskills.io open standard, a root SKILLS.md index with install instructions for 4 runtimes (Claude Code, Cursor, OpenCode, Goose), and per-runtime config.

  Each skill packages rBuilder CLI workflows into a self-contained SKILL.md with YAML frontmatter, 6 structured body sections (Prerequisites, Decision Tree, Output Contract, Stop Conditions, Failure Playbook,
  Example Turn), and a references/commands.md for full JSON output shapes.

  ## Fixes #20

  ## Type of Change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Performance improvement
  - [x] Documentation update
  - [ ] Language support (new language plugin)
  - [ ] Refactoring (no functional changes)

 ## Changes Made

  - Added 8 skill bundles under skills/: rbuilder-orient, rbuilder-impact, rbuilder-session, rbuilder-neighborhood, rbuilder-slice, rbuilder-security, rbuilder-migration, rbuilder-ci-gate
  - Each skill has SKILL.md (agentskills.io frontmatter + 6-section body) and references/commands.md (full JSON field tables, flag reference)
  - Added root SKILLS.md with skill index table and platform install instructions for Claude Code, Cursor, OpenCode, and Goose
  - Added .claude/settings.json with Claude Code runtime config (permissions.allow and skills paths)
  - Added cross-link in AGENTS.md pointing to SKILLS.md
  - Added SKILLS.md row in README.md Documentation table

 ## Testing

  No Rust code was changed — this PR is entirely documentation and configuration files (markdown, JSON). All CLI commands and JSON field names were verified against src/cli/mod.rs and src/cli/*_output.rs during a
  3-round spec review.

  - [ ] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [ ] Tested with cargo test
  - [ ] Manual testing performed

 ## Test environment:
  - OS: macOS
  - Rust version: stable

  ## Checklist

  - [x] My code follows the style guidelines (ran cargo fmt)
  - [x] I have performed a self-review of my code
  - [x] I have commented my code where necessary
  - [ ] I have added tests that prove my fix/feature works
  - [x] All new and existing tests pass (cargo test)
  - [x] No clippy warnings (cargo clippy --all-targets -- -D warnings)
  - [x] Documentation updated (if applicable)
  - [x] CONTRIBUTING.md guidelines followed

  ## Performance Impact

  No performance impact — no Rust code changed.

  ## Breaking Changes

  No breaking changes. This PR adds new files only; no existing files were modified beyond adding cross-link lines in AGENTS.md and README.md.

  ## Additional Notes

  - All CLI commands were validated against the actual clap definitions in src/cli/mod.rs (e.g., positional args vs flags, correct flag names like --export-format not --format, --view cfg not --with-cfg for slice)
  - All JSON field paths were validated against src/cli/*_output.rs (e.g., .metrics.impact_zone_size not .transitive_count, .pagerank.top[] not .rows[:10])
  - Helper scripts per skill are out of scope (follow-up)
  - skills-lock.json registry is out of scope (follow-up if needed)