### PR TITLE
fix(#46): Go Tier-1 call graph + shared CFG language surfaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -327,6 +327,10 @@ name = "go_cfg_analysis"
 path = "tests/go_cfg_analysis.rs"
 
 [[test]]
+name = "go_langfeatures"
+path = "tests/go_langfeatures.rs"
+
+[[test]]
 name = "dashboard_metasfresh"
 path = "tests/dashboard_metasfresh.rs"
 

--- a/crates/rbuilder-analysis/src/cfg_builder.rs
+++ b/crates/rbuilder-analysis/src/cfg_builder.rs
@@ -160,6 +160,12 @@ struct CfgBuilder<'a> {
     pending_breakable_label: Option<String>,
     /// Function-scoped `defer` stack (static approx; LIFO on return/panic).
     defer_stack: Vec<DeferredCall>,
+    /// Enclosing `finally` bodies (Java/C#-style), LIFO on return/throw.
+    finally_stack: Vec<Vec<DeferredCall>>,
+    /// Catch entry blocks for enclosing tries (Exception edges from throw sites).
+    try_catch_stack: Vec<Vec<BlockId>>,
+    /// When true, leaving a switch case falls into the next case (Java classic switch).
+    switch_implicit_fallthrough: bool,
 }
 
 struct BreakableContext {
@@ -190,6 +196,9 @@ impl<'a> CfgBuilder<'a> {
             pending_fallthrough: false,
             pending_breakable_label: None,
             defer_stack: Vec::new(),
+            finally_stack: Vec::new(),
+            try_catch_stack: Vec::new(),
+            switch_implicit_fallthrough: false,
         }
     }
 
@@ -242,6 +251,7 @@ impl<'a> CfgBuilder<'a> {
     }
 
     fn add_statement_to_current(&mut self, stmt: Statement) {
+        let kind = stmt.kind;
         let block = self
             .cfg
             .blocks
@@ -254,6 +264,26 @@ impl<'a> CfgBuilder<'a> {
             block.end_line = stmt.line;
         }
         block.statements.push(stmt);
+        // Conservative: any non-terminal stmt in a try may throw → catch.
+        if !matches!(kind, StatementKind::Return | StatementKind::Jump) {
+            self.wire_try_exception_from_current();
+        }
+    }
+
+    fn wire_try_exception_from_current(&mut self) {
+        let from = self.current_block;
+        let Some(handlers) = self.try_catch_stack.last() else {
+            return;
+        };
+        let handlers = handlers.clone();
+        for h in handlers {
+            let already = self.cfg.edges.iter().any(|e| {
+                e.from == from && e.to == h && e.edge_type == CfgEdgeType::Exception
+            });
+            if !already {
+                self.cfg.add_edge(from, h, CfgEdgeType::Exception);
+            }
+        }
     }
 
     fn visit_block(&mut self, node: Node, source: &[u8]) -> Result<BlockId> {
@@ -281,10 +311,13 @@ impl<'a> CfgBuilder<'a> {
             "do_statement" => self.visit_do(node, source),
             "for_statement" | "for_expression" | "for_in_expression" | "foreach_statement"
             | "for_range_loop" => self.visit_for(node, source),
+            "enhanced_for_statement" => self.visit_enhanced_for(node, source),
             "loop_expression" => self.visit_loop(node, source),
 
             // Returns
             "return_statement" | "return_expression" => self.visit_return(node, source),
+            "yield_statement" => self.visit_return(node, source),
+            "throw_statement" => self.visit_throw(node, source),
 
             // Jumps
             "break_expression" | "break_statement" => self.visit_break(node, source),
@@ -305,6 +338,7 @@ impl<'a> CfgBuilder<'a> {
             | "const_declaration"
             | "variable_declaration"
             | "local_declaration_statement"
+            | "local_variable_declaration"
             | "declaration" => {
                 self.add_statement(node, source, StatementKind::Declaration)?;
                 Ok(())
@@ -318,7 +352,7 @@ impl<'a> CfgBuilder<'a> {
                 self.add_statement(node, source, StatementKind::Assignment)?;
                 Ok(())
             }
-            "inc_statement" | "dec_statement" | "send_statement" => {
+            "inc_statement" | "dec_statement" | "send_statement" | "update_expression" => {
                 self.add_statement(node, source, StatementKind::Expression)?;
                 Ok(())
             }
@@ -329,10 +363,11 @@ impl<'a> CfgBuilder<'a> {
             // Rust match
             "match_expression" => self.visit_match(node, source),
 
-            // Go / shared switch & select
-            "switch_statement" | "type_switch_statement" | "expression_switch_statement" => {
-                self.visit_switch(node, source)
-            }
+            // Switch (Go + Java `switch_expression`)
+            "switch_statement"
+            | "type_switch_statement"
+            | "expression_switch_statement"
+            | "switch_expression" => self.visit_switch(node, source),
             "select_statement" => self.visit_select(node, source),
 
             // Go concurrency helpers
@@ -342,8 +377,12 @@ impl<'a> CfgBuilder<'a> {
                 Ok(())
             }
 
-            // Python try/except (simplified)
-            "try_statement" => self.visit_try(node, source),
+            // try / try-with-resources
+            "try_statement" | "try_with_resources_statement" => self.visit_try(node, source),
+            "assert_statement" => {
+                self.add_statement(node, source, StatementKind::Branch)?;
+                Ok(())
+            }
 
             // Block / body wrapper
             k if is_block_like(k) => {
@@ -554,34 +593,30 @@ impl<'a> CfgBuilder<'a> {
     }
 
     fn visit_for(&mut self, node: Node, source: &[u8]) -> Result<()> {
-        // Language-specific loop header pieces (Go for_clause / range_clause, C-like initializer).
+        // Go: for_clause / range_clause. Java/C-like: fields init/condition/update.
         let mut for_clause = None;
         let mut range_clause = None;
-        let mut while_cond = None;
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
             match child.kind() {
                 "for_clause" => for_clause = Some(child),
                 "range_clause" => range_clause = Some(child),
-                k if while_cond.is_none()
-                    && child.is_named()
-                    && k != "block"
-                    && !is_block_like(k)
-                    && k != "for_clause"
-                    && k != "range_clause" =>
-                {
-                    // while-style `for cond { }` — bare condition expression child
-                    while_cond = Some(child);
-                }
                 _ => {}
             }
         }
 
+        // Init
         if let Some(clause) = for_clause {
-            if let Some(init) = clause.child_by_field_name("initializer") {
+            if let Some(init) = clause
+                .child_by_field_name("initializer")
+                .or_else(|| clause.child_by_field_name("init"))
+            {
                 self.visit_statement(init, source)?;
             }
-        } else if let Some(init) = node.child_by_field_name("initializer") {
+        } else if let Some(init) = node
+            .child_by_field_name("init")
+            .or_else(|| node.child_by_field_name("initializer"))
+        {
             self.visit_statement(init, source)?;
         } else if let Some(range) = range_clause {
             self.add_statement(range, source, StatementKind::Expression)?;
@@ -595,10 +630,37 @@ impl<'a> CfgBuilder<'a> {
         let body = self.new_block();
         let exit = self.new_block();
 
+        // Condition — prefer explicit fields; Go while-style bare expr only if no init/update fields.
         let cond_node = for_clause
             .and_then(|c| c.child_by_field_name("condition"))
-            .or(while_cond)
-            .or_else(|| node.child_by_field_name("condition"));
+            .or_else(|| node.child_by_field_name("condition"))
+            .or_else(|| {
+                // Go `for cond {}` — single expression child, not a declaration/update.
+                if for_clause.is_some() || range_clause.is_some() {
+                    return None;
+                }
+                if node.child_by_field_name("init").is_some()
+                    || node.child_by_field_name("update").is_some()
+                {
+                    return None;
+                }
+                let mut c = node.walk();
+                for child in node.children(&mut c) {
+                    if child.is_named()
+                        && child.kind() != "block"
+                        && !is_block_like(child.kind())
+                        && !matches!(
+                            child.kind(),
+                            "local_variable_declaration"
+                                | "update_expression"
+                                | "assignment_expression"
+                        )
+                    {
+                        return Some(child);
+                    }
+                }
+                None
+            });
 
         if let Some(cond) = cond_node {
             self.wire_condition(cond, source, body, exit)?;
@@ -623,16 +685,29 @@ impl<'a> CfgBuilder<'a> {
             self.cfg.add_edge(header, exit, CfgEdgeType::IfFalse);
         }
 
-        let update_block = if let Some(clause) = for_clause {
-            clause.child_by_field_name("update").map(|update_node| {
-                let update_block = self.new_block();
-                (update_block, update_node)
-            })
+        // Updates (Go for_clause.update or Java field "update" — possibly multiple).
+        let mut update_nodes: Vec<Node> = Vec::new();
+        if let Some(clause) = for_clause {
+            if let Some(u) = clause.child_by_field_name("update") {
+                update_nodes.push(u);
+            }
         } else {
-            None
-        };
+            let mut c = node.walk();
+            let mut idx = 0u32;
+            for child in node.children(&mut c) {
+                if node.field_name_for_child(idx) == Some("update") {
+                    update_nodes.push(child);
+                }
+                idx += 1;
+            }
+        }
 
-        let continue_target = update_block.map(|(id, _)| id).unwrap_or(header);
+        let update_block = if update_nodes.is_empty() {
+            None
+        } else {
+            Some(self.new_block())
+        };
+        let continue_target = update_block.unwrap_or(header);
         self.breakable_stack.push(BreakableContext {
             exit,
             continue_target: Some(continue_target),
@@ -649,16 +724,62 @@ impl<'a> CfgBuilder<'a> {
                 .add_edge(self.current_block, continue_target, CfgEdgeType::Jump);
         }
 
-        if let Some((update_id, update_node)) = update_block {
+        if let Some(update_id) = update_block {
             self.flow_active = true;
             self.current_block = update_id;
-            self.visit_statement(update_node, source)?;
+            for u in update_nodes {
+                self.visit_statement(u, source)?;
+            }
             if self.flow_active {
                 self.cfg
                     .add_edge(self.current_block, header, CfgEdgeType::Next);
             }
         }
 
+        self.breakable_stack.pop();
+        self.flow_active = true;
+        self.current_block = exit;
+        Ok(())
+    }
+
+    fn visit_enhanced_for(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        if let Some(value) = node.child_by_field_name("value") {
+            self.add_statement(value, source, StatementKind::Expression)?;
+        }
+        let header = self.new_block();
+        self.cfg
+            .add_edge(self.current_block, header, CfgEdgeType::Next);
+        self.current_block = header;
+        let header_text = node
+            .child_by_field_name("value")
+            .and_then(|v| v.utf8_text(source).ok())
+            .map(|s| format!("for-each {s}"))
+            .unwrap_or_else(|| "for-each".to_string());
+        self.add_statement_to_current(Statement {
+            kind: StatementKind::Branch,
+            line: node.start_position().row + 1,
+            text: header_text,
+            defined_vars: HashSet::new(),
+            used_vars: HashSet::new(),
+        });
+        let body = self.new_block();
+        let exit = self.new_block();
+        self.cfg.add_edge(header, body, CfgEdgeType::IfTrue);
+        self.cfg.add_edge(header, exit, CfgEdgeType::IfFalse);
+        self.breakable_stack.push(BreakableContext {
+            exit,
+            continue_target: Some(header),
+            label: self.pending_breakable_label.take(),
+        });
+        self.flow_active = true;
+        self.current_block = body;
+        if let Some(body_node) = node.child_by_field_name("body") {
+            self.visit_block(body_node, source)?;
+        }
+        if self.flow_active {
+            self.cfg
+                .add_edge(self.current_block, header, CfgEdgeType::Jump);
+        }
         self.breakable_stack.pop();
         self.flow_active = true;
         self.current_block = exit;
@@ -693,8 +814,76 @@ impl<'a> CfgBuilder<'a> {
     }
 
     fn visit_return(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        // Java: `return switch (...) { ... };` — lower the switch CFG, then exit.
+        if let Some(sw) = {
+            let mut found = None;
+            let mut c = node.walk();
+            for ch in node.children(&mut c) {
+                if ch.kind() == "switch_expression" {
+                    found = Some(ch);
+                    break;
+                }
+            }
+            found
+        } {
+            self.visit_switch(sw, source)?;
+            if !self.flow_active {
+                return Ok(());
+            }
+            self.add_statement_to_current(Statement {
+                kind: StatementKind::Return,
+                line: node.start_position().row + 1,
+                text: "return".to_string(),
+                defined_vars: HashSet::new(),
+                used_vars: HashSet::new(),
+            });
+            self.unwind_finallies(source)?;
+            self.unwind_defers_to_exit(CfgEdgeType::Return);
+            return Ok(());
+        }
+
         self.add_statement(node, source, StatementKind::Return)?;
+        self.unwind_finallies(source)?;
         self.unwind_defers_to_exit(CfgEdgeType::Return);
+        Ok(())
+    }
+
+    fn visit_throw(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        self.add_statement(node, source, StatementKind::Jump)?;
+        // Inside try: route to catch entries (finally runs when leaving via catch/completion).
+        if let Some(handlers) = self.try_catch_stack.last() {
+            let handlers = handlers.clone();
+            for h in handlers {
+                self.cfg
+                    .add_edge(self.current_block, h, CfgEdgeType::Exception);
+            }
+            self.flow_active = false;
+            self.current_block = self.new_block();
+            return Ok(());
+        }
+        self.unwind_finallies(source)?;
+        self.unwind_defers_to_exit(CfgEdgeType::Exception);
+        Ok(())
+    }
+
+    /// Emit enclosing `finally` bodies (outermost last) before a terminal exit.
+    fn unwind_finallies(&mut self, _source: &[u8]) -> Result<()> {
+        let frames: Vec<Vec<DeferredCall>> = self.finally_stack.iter().rev().cloned().collect();
+        for stmts in frames {
+            for d in stmts {
+                let b = self.new_block();
+                self.cfg
+                    .add_edge(self.current_block, b, CfgEdgeType::Next);
+                self.current_block = b;
+                self.add_statement_to_current(Statement {
+                    kind: StatementKind::Expression,
+                    line: d.line,
+                    text: d.text,
+                    defined_vars: HashSet::new(),
+                    used_vars: HashSet::new(),
+                });
+            }
+        }
         Ok(())
     }
 
@@ -844,6 +1033,12 @@ impl<'a> CfgBuilder<'a> {
     fn visit_labeled_statement(&mut self, node: Node, source: &[u8]) -> Result<()> {
         let label = node
             .child_by_field_name("label")
+            .or_else(|| {
+                // Java: `identifier ':' statement` (no label field).
+                node.named_child(0).filter(|n| {
+                    matches!(n.kind(), "identifier" | "label_name")
+                })
+            })
             .and_then(|n| n.utf8_text(source).ok())
             .unwrap_or("")
             .trim()
@@ -859,7 +1054,6 @@ impl<'a> CfgBuilder<'a> {
         self.current_block = label_block;
         self.flow_active = true;
 
-        // `label: stmt` — visit the statement after the label (skip label_name).
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
             if !child.is_named() {
@@ -871,10 +1065,19 @@ impl<'a> CfgBuilder<'a> {
             if node.child_by_field_name("label").is_some_and(|l| l.id() == child.id()) {
                 continue;
             }
+            // Java label identifier is the first named child — skip it.
+            if child.kind() == "identifier" {
+                if let Ok(t) = child.utf8_text(source) {
+                    if t.trim() == label {
+                        continue;
+                    }
+                }
+            }
             let attach_label = matches!(
                 child.kind(),
                 "for_statement"
                     | "for_expression"
+                    | "enhanced_for_statement"
                     | "while_statement"
                     | "while_expression"
                     | "do_statement"
@@ -882,6 +1085,7 @@ impl<'a> CfgBuilder<'a> {
                     | "switch_statement"
                     | "type_switch_statement"
                     | "expression_switch_statement"
+                    | "switch_expression"
                     | "select_statement"
             );
             if attach_label {
@@ -903,6 +1107,19 @@ impl<'a> CfgBuilder<'a> {
         true_dest: BlockId,
         false_dest: BlockId,
     ) -> Result<()> {
+        // Unwrap Java/C-style `(expr)`.
+        let cond = {
+            let mut c = cond;
+            while c.kind() == "parenthesized_expression" {
+                if let Some(inner) = c.named_child(0) {
+                    c = inner;
+                } else {
+                    break;
+                }
+            }
+            c
+        };
+
         if let Some(op) = logical_operator(cond, source) {
             let left = cond
                 .child_by_field_name("left")
@@ -1069,11 +1286,11 @@ impl<'a> CfgBuilder<'a> {
         let mut has_default = false;
         let mut any_reaches_merge = false;
         let mut fallthrough_from: Option<BlockId> = None;
-        for case in cases {
-            let is_default = matches!(
-                case.kind(),
-                "default_case" | "default_statement" | "switch_default"
-            );
+        let prev_implicit = self.switch_implicit_fallthrough;
+        for case in &cases {
+            // Java classic groups fall through by default; arrow rules / Go cases do not.
+            self.switch_implicit_fallthrough = matches!(case.kind(), "switch_block_statement_group");
+            let is_default = is_switch_default_case(*case, source);
             if is_default {
                 has_default = true;
             }
@@ -1091,8 +1308,10 @@ impl<'a> CfgBuilder<'a> {
             self.flow_active = true;
             self.pending_fallthrough = false;
             self.current_block = case_block;
-            self.visit_case_body(case, source)?;
-            if self.pending_fallthrough {
+            self.visit_case_body(*case, source)?;
+
+            let implicit = self.switch_implicit_fallthrough && self.flow_active;
+            if self.pending_fallthrough || implicit {
                 fallthrough_from = Some(self.current_block);
                 self.pending_fallthrough = false;
             } else if self.flow_active {
@@ -1100,6 +1319,13 @@ impl<'a> CfgBuilder<'a> {
                     .add_edge(self.current_block, merge, CfgEdgeType::Next);
                 any_reaches_merge = true;
             }
+        }
+        self.switch_implicit_fallthrough = prev_implicit;
+
+        // Trailing fallthrough with no next case → merge.
+        if let Some(src) = fallthrough_from {
+            self.cfg.add_edge(src, merge, CfgEdgeType::Next);
+            any_reaches_merge = true;
         }
 
         if !has_default {
@@ -1116,16 +1342,45 @@ impl<'a> CfgBuilder<'a> {
         Ok(())
     }
 
-    /// Lower switch/select case bodies (Go uses `statement_list`, others may use `body`).
+    /// Lower switch/select case bodies.
     fn visit_case_body(&mut self, case: Node, source: &[u8]) -> Result<()> {
         if let Some(body) = case.child_by_field_name("body") {
             self.visit_block(body, source)?;
             return Ok(());
         }
-        let mut cursor = case.walk();
-        for child in case.children(&mut cursor) {
-            if child.kind() == "statement_list" || is_block_like(child.kind()) {
-                self.visit_block(child, source)?;
+        match case.kind() {
+            "switch_block_statement_group" => {
+                let mut c = case.walk();
+                for child in case.children(&mut c) {
+                    if !child.is_named() {
+                        continue;
+                    }
+                    // Skip labels (`case 1:` / `default:`).
+                    if child.kind() == "switch_label" {
+                        continue;
+                    }
+                    self.visit_statement(child, source)?;
+                }
+            }
+            "switch_rule" => {
+                let mut c = case.walk();
+                for child in case.children(&mut c) {
+                    if !child.is_named() {
+                        continue;
+                    }
+                    if child.kind() == "switch_label" {
+                        continue;
+                    }
+                    self.visit_statement(child, source)?;
+                }
+            }
+            _ => {
+                let mut cursor = case.walk();
+                for child in case.children(&mut cursor) {
+                    if child.kind() == "statement_list" || is_block_like(child.kind()) {
+                        self.visit_block(child, source)?;
+                    }
+                }
             }
         }
         Ok(())
@@ -1136,50 +1391,228 @@ impl<'a> CfgBuilder<'a> {
     }
 
     fn visit_try(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        // Snapshot finally + resource closes before body so return/throw can unwind them.
+        let mut finally_snapshot: Option<Vec<DeferredCall>> = None;
+        let mut catch_nodes: Vec<Node> = Vec::new();
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            match child.kind() {
+                "finally_clause" => {
+                    finally_snapshot = Some(snapshot_block_stmts(child, source));
+                }
+                "except_clause" | "except_handler" | "catch_clause" => {
+                    catch_nodes.push(child);
+                }
+                _ => {}
+            }
+        }
+        let resource_closes = snapshot_resource_closes(node, source);
+
+        // Push order: user finally first, then resource closes → LIFO runs closes then finally.
+        let pushed_finally = finally_snapshot.is_some();
+        let pushed_closes = !resource_closes.is_empty();
+        if let Some(ref snap) = finally_snapshot {
+            self.finally_stack.push(snap.clone());
+        }
+        if pushed_closes {
+            self.finally_stack.push(resource_closes.clone());
+        }
+
+        // Pre-create catch entries so body statements can Exception-edge to them.
+        let catch_entries: Vec<BlockId> = catch_nodes.iter().map(|_| self.new_block()).collect();
+        if !catch_entries.is_empty() {
+            self.try_catch_stack.push(catch_entries.clone());
+        }
+
+        // Resource declarations run before the try body.
+        if let Some(resources) = node.child_by_field_name("resources") {
+            let mut c = resources.walk();
+            for child in resources.children(&mut c) {
+                if child.kind() == "resource" {
+                    self.add_statement(child, source, StatementKind::Declaration)?;
+                }
+            }
+        }
+
         let try_block = self.new_block();
         self.cfg
             .add_edge(self.current_block, try_block, CfgEdgeType::Next);
         self.current_block = try_block;
+        // Always link try entry → catch (covers return-only / empty bodies).
+        for &h in &catch_entries {
+            self.cfg.add_edge(try_block, h, CfgEdgeType::Exception);
+        }
         if let Some(body) = node.child_by_field_name("body") {
             self.visit_block(body, source)?;
         }
+        if !catch_entries.is_empty() {
+            self.try_catch_stack.pop();
+        }
+        let try_reached_end = self.flow_active;
         let mut try_end = self.current_block;
         let merge = self.new_block();
 
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
-            if child.kind() == "except_clause"
-                || child.kind() == "except_handler"
-                || child.kind() == "catch_clause"
-            {
-                let handler = self.new_block();
-                self.cfg
-                    .add_edge(try_block, handler, CfgEdgeType::Exception);
-                self.current_block = handler;
-                if let Some(block) = child.child_by_field_name("body") {
-                    self.visit_block(block, source)?;
-                } else if child.kind() == "catch_clause" {
-                    if let Some(block) = find_child_kind(child, "block") {
-                        self.visit_block(block, source)?;
-                    }
-                }
-                self.cfg
-                    .add_edge(self.current_block, merge, CfgEdgeType::Next);
-            } else if child.kind() == "finally_clause" {
-                let finally = self.new_block();
-                self.cfg.add_edge(try_end, finally, CfgEdgeType::Next);
-                self.current_block = finally;
-                if let Some(block) = find_child_kind(child, "block") {
+        for (i, catch_node) in catch_nodes.iter().enumerate() {
+            let handler = catch_entries[i];
+            self.flow_active = true;
+            self.current_block = handler;
+            if let Some(block) = catch_node.child_by_field_name("body") {
+                self.visit_block(block, source)?;
+            } else if catch_node.kind() == "catch_clause" {
+                if let Some(block) = find_child_kind(*catch_node, "block") {
                     self.visit_block(block, source)?;
                 }
-                try_end = self.current_block;
+            }
+            if self.flow_active {
+                self.unwind_finallies(source)?;
+                if self.flow_active {
+                    self.cfg
+                        .add_edge(self.current_block, merge, CfgEdgeType::Next);
+                }
             }
         }
 
-        self.cfg.add_edge(try_end, merge, CfgEdgeType::Next);
+        if try_reached_end {
+            self.flow_active = true;
+            self.current_block = try_end;
+            // Same order as unwind_finallies: reverse stack = closes then user finally.
+            if pushed_closes {
+                for d in &resource_closes {
+                    let b = self.new_block();
+                    self.cfg
+                        .add_edge(self.current_block, b, CfgEdgeType::Next);
+                    self.current_block = b;
+                    self.add_statement_to_current(Statement {
+                        kind: StatementKind::Expression,
+                        line: d.line,
+                        text: d.text.clone(),
+                        defined_vars: HashSet::new(),
+                        used_vars: HashSet::new(),
+                    });
+                }
+            }
+            if let Some(ref stmts) = finally_snapshot {
+                for d in stmts {
+                    let b = self.new_block();
+                    self.cfg
+                        .add_edge(self.current_block, b, CfgEdgeType::Next);
+                    self.current_block = b;
+                    self.add_statement_to_current(Statement {
+                        kind: StatementKind::Expression,
+                        line: d.line,
+                        text: d.text.clone(),
+                        defined_vars: HashSet::new(),
+                        used_vars: HashSet::new(),
+                    });
+                }
+            }
+            try_end = self.current_block;
+            self.cfg.add_edge(try_end, merge, CfgEdgeType::Next);
+        }
+
+        if pushed_closes {
+            self.finally_stack.pop();
+        }
+        if pushed_finally {
+            self.finally_stack.pop();
+        }
+
+        self.flow_active = true;
         self.current_block = merge;
         Ok(())
     }
+}
+
+fn snapshot_resource_closes(node: Node, source: &[u8]) -> Vec<DeferredCall> {
+    let Some(resources) = node.child_by_field_name("resources") else {
+        return Vec::new();
+    };
+    let mut names: Vec<(String, usize)> = Vec::new();
+    let mut c = resources.walk();
+    for child in resources.children(&mut c) {
+        if child.kind() != "resource" {
+            continue;
+        }
+        let line = child.start_position().row + 1;
+        let name = child
+            .child_by_field_name("name")
+            .and_then(|n| n.utf8_text(source).ok())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty() && s != "_")
+            .or_else(|| {
+                // `try (alreadyOpen)` / `try (obj.field)` — no `name` field.
+                if child.child_by_field_name("type").is_some() {
+                    return None;
+                }
+                child
+                    .named_child(0)
+                    .and_then(|n| n.utf8_text(source).ok())
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+            });
+        if let Some(name) = name {
+            names.push((name, line));
+        }
+    }
+    // Close in reverse declaration order (JLS).
+    names
+        .into_iter()
+        .rev()
+        .map(|(name, line)| DeferredCall {
+            text: format!("{name}.close()"),
+            line,
+        })
+        .collect()
+}
+
+fn snapshot_block_stmts(node: Node, source: &[u8]) -> Vec<DeferredCall> {
+    let mut out = Vec::new();
+    let block = find_child_kind(node, "block").unwrap_or(node);
+    let mut stack = vec![block];
+    while let Some(n) = stack.pop() {
+        if matches!(
+            n.kind(),
+            "expression_statement"
+                | "method_invocation"
+                | "return_statement"
+                | "local_variable_declaration"
+                | "throw_statement"
+        ) {
+            if let Ok(t) = n.utf8_text(source) {
+                out.push(DeferredCall {
+                    text: t.trim().to_string(),
+                    line: n.start_position().row + 1,
+                });
+            }
+            continue;
+        }
+        let mut c = n.walk();
+        let children: Vec<_> = n.children(&mut c).filter(|ch| ch.is_named()).collect();
+        for ch in children.into_iter().rev() {
+            stack.push(ch);
+        }
+    }
+    out
+}
+
+fn is_switch_default_case(case: Node, source: &[u8]) -> bool {
+    if matches!(
+        case.kind(),
+        "default_case" | "default_statement" | "switch_default"
+    ) {
+        return true;
+    }
+    let mut c = case.walk();
+    for child in case.children(&mut c) {
+        if child.kind() == "switch_label" {
+            if let Ok(t) = child.utf8_text(source) {
+                if t.trim().starts_with("default") {
+                    return true;
+                }
+            }
+        }
+    }
+    false
 }
 
 fn find_child_kind<'a>(node: Node<'a>, kind: &str) -> Option<Node<'a>> {
@@ -1199,7 +1632,7 @@ fn collect_switch_cases<'a>(node: Node<'a>, cases: &mut Vec<Node<'a>>) {
     match node.kind() {
         "expression_case" | "type_case" | "case_clause" | "default_case" | "default_statement"
         | "case_statement" | "communication_case" | "switch_section" | "switch_case"
-        | "switch_default" => cases.push(node),
+        | "switch_default" | "switch_block_statement_group" | "switch_rule" => cases.push(node),
         _ => {
             let mut cursor = node.walk();
             for child in node.children(&mut cursor) {
@@ -2083,4 +2516,523 @@ function classify(v) {
         let result = build_cfg_for_function("rust", code, "missing");
         assert!(matches!(result, Err(Error::NotFound(_))));
     }
+
+    fn java_texts(cfg: &ControlFlowGraph) -> Vec<String> {
+        cfg.blocks
+            .values()
+            .flat_map(|b| b.statements.iter().map(|s| s.text.clone()))
+            .collect()
+    }
+
+    fn java_kinds(cfg: &ControlFlowGraph) -> Vec<StatementKind> {
+        cfg.blocks
+            .values()
+            .flat_map(|b| b.statements.iter().map(|s| s.kind))
+            .collect()
+    }
+
+    fn java_block_ids(cfg: &ControlFlowGraph, needle: &str) -> Vec<uuid::Uuid> {
+        cfg.blocks
+            .values()
+            .filter(|b| b.statements.iter().any(|s| s.text.contains(needle)))
+            .map(|b| b.id)
+            .collect()
+    }
+
+    #[test]
+    fn test_java_if_else_cfg() {
+        let code = r#"
+public class Demo {
+    public int abs(int x) {
+        if (x > 0) {
+            return x;
+        }
+        return -x;
+    }
 }
+"#;
+        let cfg = build_cfg_for_function("java", code, "abs").unwrap();
+        assert!(cfg.blocks.len() >= 4);
+        assert!(cfg
+            .edges
+            .iter()
+            .any(|e| e.edge_type == CfgEdgeType::IfTrue));
+        assert!(
+            java_kinds(&cfg)
+                .iter()
+                .filter(|k| **k == StatementKind::Return)
+                .count()
+                >= 2
+        );
+    }
+
+    #[test]
+    fn test_java_short_circuit_and() {
+        let code = r#"
+public class Demo {
+    public int sc(boolean a, boolean b) {
+        if (a && b) {
+            return 1;
+        }
+        return 0;
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("java", code, "sc").unwrap();
+        let texts = java_texts(&cfg);
+        assert!(
+            texts.iter().any(|t| t.trim() == "a" || t == "a"),
+            "&& left must be its own branch, got {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t.trim() == "b" || t == "b"),
+            "&& right must be its own branch, got {texts:?}"
+        );
+        assert!(
+            !texts.iter().any(|t| t.contains("a && b")),
+            "must not keep (a && b) as one blob, got {texts:?}"
+        );
+    }
+
+    #[test]
+    fn test_java_for_clause_init_cond_update() {
+        let code = r#"
+public class Demo {
+    public int sum(int n) {
+        int total = 0;
+        for (int i = 0; i < n; i++) {
+            if (i == 1) {
+                continue;
+            }
+            total += i;
+        }
+        return total;
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("java", code, "sum").unwrap();
+        let texts = java_texts(&cfg);
+        assert!(
+            texts.iter().any(|t| t.contains("i = 0") || t.contains("i=0")),
+            "for init, got {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t.contains("i < n") || t.contains("i<n")),
+            "for condition, got {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t.contains("i++")),
+            "for update, got {texts:?}"
+        );
+        assert!(cfg.has_cycle());
+        let cont = java_block_ids(&cfg, "continue");
+        let updates = java_block_ids(&cfg, "i++");
+        assert!(
+            cont.iter().any(|c| {
+                cfg.edges
+                    .iter()
+                    .any(|e| e.from == *c && updates.contains(&e.to) && e.edge_type == CfgEdgeType::Jump)
+            }),
+            "continue must Jump to i++"
+        );
+    }
+
+    #[test]
+    fn test_java_enhanced_for_has_cycle() {
+        let code = r#"
+public class Demo {
+    public int sum(int[] a) {
+        int t = 0;
+        for (int v : a) {
+            t += v;
+        }
+        return t;
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("java", code, "sum").unwrap();
+        assert!(cfg.has_cycle(), "enhanced for must cycle");
+        assert!(
+            !java_texts(&cfg)
+                .iter()
+                .any(|t| t.trim_start().starts_with("for (int v")),
+            "enhanced for must not remain opaque blob, got {:?}",
+            java_texts(&cfg)
+        );
+        assert!(
+            java_texts(&cfg).iter().any(|t| t.contains("t += v") || t.contains("t+=v")),
+            "body must be lowered"
+        );
+    }
+
+    #[test]
+    fn test_java_switch_cases_emit_returns() {
+        let code = r#"
+public class Demo {
+    public int pick(int x) {
+        switch (x) {
+            case 1:
+                return 10;
+            case 2:
+                return 20;
+            default:
+                return 0;
+        }
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("java", code, "pick").unwrap();
+        assert!(
+            java_kinds(&cfg)
+                .iter()
+                .filter(|k| **k == StatementKind::Return)
+                .count()
+                >= 3,
+            "case returns must lower, kinds={:?}",
+            java_kinds(&cfg)
+        );
+        assert!(
+            !java_texts(&cfg)
+                .iter()
+                .any(|t| t.trim_start().starts_with("switch")),
+            "switch must not be opaque blob"
+        );
+        let returns = cfg
+            .edges
+            .iter()
+            .filter(|e| e.edge_type == CfgEdgeType::Return)
+            .count();
+        assert!(returns >= 3, "Return edges from cases, got {returns}");
+    }
+
+    #[test]
+    fn test_java_switch_arrow_rules() {
+        let code = r#"
+public class Demo {
+    public int pick(int x) {
+        return switch (x) {
+            case 1 -> 10;
+            case 2 -> 20;
+            default -> 0;
+        };
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("java", code, "pick").unwrap();
+        // Arrow arms should appear as distinct branch targets (expressions or returns).
+        assert!(
+            cfg.edges
+                .iter()
+                .filter(|e| e.edge_type == CfgEdgeType::IfTrue)
+                .count()
+                >= 2,
+            "arrow switch needs arm fan-out"
+        );
+        assert!(
+            !java_texts(&cfg)
+                .iter()
+                .any(|t| t.contains("case 1 ->") && t.contains("default")),
+            "arrow switch must not stay one blob, got {:?}",
+            java_texts(&cfg)
+        );
+    }
+
+    #[test]
+    fn test_java_labeled_break_continue() {
+        let code = r#"
+public class Demo {
+    public int nested() {
+        int n = 0;
+        outer:
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                if (j == 1) {
+                    continue outer;
+                }
+                if (j == 2) {
+                    break outer;
+                }
+                n++;
+            }
+        }
+        return n;
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("java", code, "nested").unwrap();
+        let cont = java_block_ids(&cfg, "continue outer");
+        let brk = java_block_ids(&cfg, "break outer");
+        let updates = java_block_ids(&cfg, "i++");
+        assert!(!cont.is_empty() && !brk.is_empty() && !updates.is_empty());
+        assert!(
+            cont.iter().any(|c| {
+                cfg.edges.iter().any(|e| {
+                    e.from == *c && updates.contains(&e.to) && e.edge_type == CfgEdgeType::Jump
+                })
+            }),
+            "continue outer must Jump to outer i++"
+        );
+        assert!(
+            brk.iter().any(|b| {
+                cfg.edges.iter().any(|e| {
+                    e.from == *b
+                        && e.edge_type == CfgEdgeType::Jump
+                        && updates.iter().all(|u| e.to != *u)
+                })
+            }),
+            "break outer must Jump to outer exit, not i++"
+        );
+    }
+
+    #[test]
+    fn test_java_try_catch_exception_edge() {
+        let code = r#"
+public class Demo {
+    public int twc() {
+        try {
+            return 1;
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("java", code, "twc").unwrap();
+        assert!(
+            cfg.edges
+                .iter()
+                .any(|e| e.edge_type == CfgEdgeType::Exception),
+            "try/catch needs Exception edge"
+        );
+        assert!(
+            java_kinds(&cfg)
+                .iter()
+                .filter(|k| **k == StatementKind::Return)
+                .count()
+                >= 2
+        );
+    }
+
+    #[test]
+    fn test_java_try_with_resources() {
+        let code = r#"
+public class Demo {
+    public int twr() throws Exception {
+        try (java.io.StringReader r = new java.io.StringReader("")) {
+            return 1;
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("java", code, "twr").unwrap();
+        assert!(
+            !java_texts(&cfg)
+                .iter()
+                .any(|t| t.trim_start().starts_with("try (")),
+            "try-with-resources must not be opaque, got {:?}",
+            java_texts(&cfg)
+        );
+        assert!(
+            cfg.edges
+                .iter()
+                .any(|e| e.edge_type == CfgEdgeType::Exception)
+                || java_kinds(&cfg)
+                    .iter()
+                    .any(|k| *k == StatementKind::Return),
+            "twr should lower body/catch"
+        );
+    }
+
+    #[test]
+    fn test_java_try_with_resources_close_on_return() {
+        let code = r#"
+public class Demo {
+    public int twr() throws Exception {
+        try (java.io.StringReader r = new java.io.StringReader("");
+             java.io.StringReader s = new java.io.StringReader("")) {
+            return 1;
+        } finally {
+            System.out.println("userFinally");
+        }
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("java", code, "twr").unwrap();
+        let texts = java_texts(&cfg);
+        assert!(
+            texts.iter().any(|t| t.contains("s.close()")),
+            "later resource must close first (LIFO), got {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t.contains("r.close()")),
+            "earlier resource must close, got {texts:?}"
+        );
+        assert!(
+            texts
+                .iter()
+                .any(|t| t.contains("userFinally") || t.contains("println")),
+            "user finally must still run, got {texts:?}"
+        );
+        let ret = java_block_ids(&cfg, "return 1");
+        let close_s = java_block_ids(&cfg, "s.close()");
+        assert!(!ret.is_empty() && !close_s.is_empty());
+        assert!(
+            ret.iter().any(|r| {
+                close_s.iter().any(|c| {
+                    cfg.edges.iter().any(|e| e.from == *r && e.to == *c)
+                        || {
+                            use std::collections::{HashSet, VecDeque};
+                            let mut seen = HashSet::new();
+                            let mut q = VecDeque::from([*r]);
+                            while let Some(n) = q.pop_front() {
+                                if n == *c {
+                                    return true;
+                                }
+                                if !seen.insert(n) {
+                                    continue;
+                                }
+                                for e in &cfg.edges {
+                                    if e.from == n {
+                                        q.push_back(e.to);
+                                    }
+                                }
+                            }
+                            false
+                        }
+                })
+            }),
+            "return must reach resource close before exit"
+        );
+    }
+
+    #[test]
+    fn test_java_try_exception_from_body_statement() {
+        let code = r#"
+public class Demo {
+    public int twc() {
+        try {
+            System.out.println("mayThrow");
+            return 1;
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("java", code, "twc").unwrap();
+        let throw_sites = java_block_ids(&cfg, "mayThrow");
+        let catch_rets = java_block_ids(&cfg, "return 0");
+        assert!(!throw_sites.is_empty(), "body call must lower");
+        assert!(!catch_rets.is_empty(), "catch return must lower");
+        assert!(
+            throw_sites.iter().any(|from| {
+                cfg.edges.iter().any(|e| {
+                    e.from == *from
+                        && e.edge_type == CfgEdgeType::Exception
+                        && {
+                            // Exception target can reach catch return
+                            use std::collections::{HashSet, VecDeque};
+                            let mut seen = HashSet::new();
+                            let mut q = VecDeque::from([e.to]);
+                            while let Some(n) = q.pop_front() {
+                                if catch_rets.contains(&n) {
+                                    return true;
+                                }
+                                if !seen.insert(n) {
+                                    continue;
+                                }
+                                for edge in &cfg.edges {
+                                    if edge.from == n {
+                                        q.push_back(edge.to);
+                                    }
+                                }
+                            }
+                            false
+                        }
+                })
+            }),
+            "Exception edge must leave the body statement block, not only try entry"
+        );
+    }
+
+    #[test]
+    fn test_java_finally_on_return() {
+        let code = r#"
+public class Demo {
+    public int withFinally() {
+        try {
+            return 1;
+        } finally {
+            System.out.println("cleanup");
+        }
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("java", code, "withFinally").unwrap();
+        let texts = java_texts(&cfg);
+        assert!(
+            texts.iter().any(|t| t.contains("cleanup") || t.contains("println")),
+            "finally body must run on return path, got {texts:?}"
+        );
+        let ret = java_block_ids(&cfg, "return 1");
+        let cleanup = java_block_ids(&cfg, "cleanup");
+        let cleanup2 = java_block_ids(&cfg, "println");
+        let cleans: Vec<_> = cleanup.into_iter().chain(cleanup2).collect();
+        assert!(!ret.is_empty() && !cleans.is_empty());
+        assert!(
+            ret.iter().any(|r| {
+                cleans.iter().any(|c| {
+                    cfg.edges.iter().any(|e| e.from == *r && e.to == *c)
+                        || {
+                            use std::collections::{HashSet, VecDeque};
+                            let mut seen = HashSet::new();
+                            let mut q = VecDeque::from([*r]);
+                            while let Some(n) = q.pop_front() {
+                                if n == *c {
+                                    return true;
+                                }
+                                if !seen.insert(n) {
+                                    continue;
+                                }
+                                for e in &cfg.edges {
+                                    if e.from == n {
+                                        q.push_back(e.to);
+                                    }
+                                }
+                            }
+                            false
+                        }
+                })
+            }),
+            "return must reach finally cleanup"
+        );
+    }
+
+    #[test]
+    fn test_java_throw_exits() {
+        let code = r#"
+public class Demo {
+    public void boom() {
+        throw new RuntimeException("x");
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("java", code, "boom").unwrap();
+        assert!(
+            java_texts(&cfg).iter().any(|t| t.contains("throw")),
+            "throw must appear"
+        );
+        assert!(
+            cfg.edges.iter().any(|e| {
+                matches!(
+                    e.edge_type,
+                    CfgEdgeType::Exception | CfgEdgeType::Return | CfgEdgeType::Jump
+                )
+            }),
+            "throw must terminate with Exception/Return/Jump edge"
+        );
+    }
+}
+

--- a/crates/rbuilder-analysis/src/cfg_builder.rs
+++ b/crates/rbuilder-analysis/src/cfg_builder.rs
@@ -317,10 +317,15 @@ impl<'a> CfgBuilder<'a> {
             "enhanced_for_statement" => self.visit_enhanced_for(node, source),
             "loop_expression" => self.visit_loop(node, source),
 
-            // Returns
-            "return_statement" | "return_expression" => self.visit_return(node, source),
-            "yield_statement" => self.visit_return(node, source),
-            "throw_statement" => self.visit_throw(node, source),
+            // Returns / coroutine returns
+            "return_statement" | "return_expression" | "co_return_statement" => {
+                self.visit_return(node, source)
+            }
+            "yield_statement" | "co_yield_statement" | "co_yield_expression" => {
+                self.visit_co_yield(node, source)
+            }
+            "throw_statement" | "throw_expression" => self.visit_throw(node, source),
+            "co_await_expression" => self.visit_co_await(node, source),
 
             // Jumps
             "break_expression" | "break_statement" => self.visit_break(node, source),
@@ -345,7 +350,17 @@ impl<'a> CfgBuilder<'a> {
             | "variable_declaration"
             | "local_declaration_statement"
             | "local_variable_declaration"
-            | "declaration" => {
+            | "declaration"
+            | "init_statement" => {
+                if node.kind() == "init_statement" {
+                    let mut c = node.walk();
+                    for child in node.children(&mut c) {
+                        if child.is_named() {
+                            self.visit_statement(child, source)?;
+                        }
+                    }
+                    return Ok(());
+                }
                 self.add_statement(node, source, StatementKind::Declaration)?;
                 Ok(())
             }
@@ -427,10 +442,10 @@ impl<'a> CfgBuilder<'a> {
             "if_statement" | "if_expression" | "while_statement" | "while_expression"
             | "for_statement" | "for_expression" | "for_in_expression" | "loop_expression"
             | "match_expression" | "return_statement" | "return_expression"
-            | "try_expression" | "await_expression" | "break_expression" | "continue_expression"
-            | "macro_invocation" | "conditional_expression" => {
-                self.visit_statement(inner, source)
-            }
+            |             "try_expression" | "await_expression" | "break_expression" | "continue_expression"
+            | "macro_invocation" | "conditional_expression" | "co_await_expression"
+            | "throw_statement" | "throw_expression" | "co_yield_statement"
+            | "co_return_statement" => self.visit_statement(inner, source),
             _ => {
                 self.visit_expr_for_control_flow(inner, source)?;
                 if !self.flow_active {
@@ -644,6 +659,41 @@ impl<'a> CfgBuilder<'a> {
         Ok(())
     }
 
+    fn visit_co_await(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        if let Some(arg) = node.child_by_field_name("argument") {
+            self.visit_expr_for_control_flow(arg, source)?;
+            if !self.flow_active {
+                return Ok(());
+            }
+        }
+        let text = node
+            .utf8_text(source)
+            .unwrap_or("co_await")
+            .trim()
+            .to_string();
+        self.add_statement_to_current(Statement {
+            kind: StatementKind::Branch,
+            line: node.start_position().row + 1,
+            text,
+            defined_vars: HashSet::new(),
+            used_vars: HashSet::new(),
+        });
+        let resume = self.new_block();
+        self.cfg
+            .add_edge(self.current_block, resume, CfgEdgeType::Next);
+        self.current_block = resume;
+        Ok(())
+    }
+
+    fn visit_co_yield(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        self.add_statement(node, source, StatementKind::Branch)?;
+        let resume = self.new_block();
+        self.cfg
+            .add_edge(self.current_block, resume, CfgEdgeType::Next);
+        self.current_block = resume;
+        Ok(())
+    }
+
     fn visit_macro_invocation(&mut self, node: Node, source: &[u8]) -> Result<()> {
         let diverging = is_diverging_macro(node, source);
         self.add_statement(
@@ -683,6 +733,17 @@ impl<'a> CfgBuilder<'a> {
             self.visit_statement(init, source)?;
         }
 
+        // C++17: init lives inside `condition_clause` (`if (auto x = f(); x)`).
+        let cond_node = node
+            .child_by_field_name("condition")
+            .or_else(|| node.child_by_field_name("operand"));
+        let (cxx_init, cond_value) = cond_node
+            .map(split_condition_clause)
+            .unwrap_or((None, None));
+        if let Some(init) = cxx_init {
+            self.visit_statement(init, source)?;
+        }
+
         let cond_block = self.new_block();
         self.cfg
             .add_edge(self.current_block, cond_block, CfgEdgeType::Next);
@@ -691,10 +752,7 @@ impl<'a> CfgBuilder<'a> {
         let true_block = self.new_block();
         let false_block = self.new_block();
 
-        if let Some(cond) = node
-            .child_by_field_name("condition")
-            .or_else(|| node.child_by_field_name("operand"))
-        {
+        if let Some(cond) = cond_value.or(cond_node) {
             self.wire_condition(cond, source, true_block, false_block)?;
         } else {
             self.add_statement_to_current(Statement {
@@ -862,6 +920,11 @@ impl<'a> CfgBuilder<'a> {
     fn visit_for(&mut self, node: Node, source: &[u8]) -> Result<()> {
         self.capture_embedded_loop_label(node, source);
 
+        // C++ range-for: `for (T v : range)`
+        if node.kind() == "for_range_loop" {
+            return self.visit_for_range(node, source);
+        }
+
         // Rust `for pat in iter` / similar for-in forms.
         if node.child_by_field_name("value").is_some()
             && node.child_by_field_name("pattern").is_some()
@@ -1019,7 +1082,60 @@ impl<'a> CfgBuilder<'a> {
         Ok(())
     }
 
-    /// Rust / for-in: `for pat in iter { body }` — iter once, then next()/body cycle.
+    /// C++ `for (T v : range) { body }`
+    fn visit_for_range(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        if let Some(right) = node.child_by_field_name("right") {
+            self.add_statement(right, source, StatementKind::Expression)?;
+        }
+        let header = self.new_block();
+        self.cfg
+            .add_edge(self.current_block, header, CfgEdgeType::Next);
+        self.current_block = header;
+        let header_text = {
+            let decl = node
+                .child_by_field_name("declarator")
+                .and_then(|d| d.utf8_text(source).ok())
+                .unwrap_or("v")
+                .trim();
+            let range = node
+                .child_by_field_name("right")
+                .and_then(|r| r.utf8_text(source).ok())
+                .unwrap_or("range")
+                .trim();
+            format!("for-range {decl} : {range}")
+        };
+        self.add_statement_to_current(Statement {
+            kind: StatementKind::Branch,
+            line: node.start_position().row + 1,
+            text: header_text,
+            defined_vars: HashSet::new(),
+            used_vars: HashSet::new(),
+        });
+        let body = self.new_block();
+        let exit = self.new_block();
+        self.cfg.add_edge(header, body, CfgEdgeType::IfTrue);
+        self.cfg.add_edge(header, exit, CfgEdgeType::IfFalse);
+        self.breakable_stack.push(BreakableContext {
+            exit,
+            continue_target: Some(header),
+            label: self.pending_breakable_label.take(),
+        });
+        self.flow_active = true;
+        self.current_block = body;
+        if let Some(body_node) = node.child_by_field_name("body") {
+            self.visit_block(body_node, source)?;
+        }
+        if self.flow_active {
+            self.cfg
+                .add_edge(self.current_block, header, CfgEdgeType::Jump);
+        }
+        self.breakable_stack.pop();
+        self.flow_active = true;
+        self.current_block = exit;
+        Ok(())
+    }
+
+    /// Rust / for-in: `for pat in iter { body }` — iter once, then next/body cycle.
     fn visit_for_in(&mut self, node: Node, source: &[u8]) -> Result<()> {
         if let Some(value) = node.child_by_field_name("value") {
             self.add_statement(value, source, StatementKind::Expression)?;
@@ -1504,13 +1620,23 @@ impl<'a> CfgBuilder<'a> {
         true_dest: BlockId,
         false_dest: BlockId,
     ) -> Result<()> {
-        // Unwrap Java/C-style `(expr)` and C++ `condition_clause`.
+        // Unwrap Java/C-style `(expr)`. C++ `condition_clause` uses the `value` field
+        // (initializer is visited separately by if/switch).
         let cond = {
             let mut c = cond;
             loop {
                 match c.kind() {
-                    "parenthesized_expression" | "condition_clause" => {
+                    "parenthesized_expression" => {
                         if let Some(inner) = c.named_child(0) {
+                            c = inner;
+                        } else {
+                            break;
+                        }
+                    }
+                    "condition_clause" => {
+                        if let Some(value) = c.child_by_field_name("value") {
+                            c = value;
+                        } else if let Some(inner) = c.named_child(0) {
                             c = inner;
                         } else {
                             break;
@@ -1719,15 +1845,25 @@ impl<'a> CfgBuilder<'a> {
             }
         }
 
+        // C++17: `switch (init; cond)` — init inside condition_clause.
+        let cond_field = node
+            .child_by_field_name("condition")
+            .or_else(|| node.child_by_field_name("value"))
+            .or_else(|| node.child_by_field_name("operand"));
+        let (cxx_init, cond_value) = cond_field
+            .map(split_condition_clause)
+            .unwrap_or((None, None));
+        if let Some(init) = cxx_init {
+            self.visit_statement(init, source)?;
+        }
+
         let cond_block = self.new_block();
         self.cfg
             .add_edge(self.current_block, cond_block, CfgEdgeType::Next);
         self.current_block = cond_block;
 
-        let branch_text = node
-            .child_by_field_name("value")
-            .or_else(|| node.child_by_field_name("condition"))
-            .or_else(|| node.child_by_field_name("operand"))
+        let branch_text = cond_value
+            .or(cond_field)
             .and_then(|c| c.utf8_text(source).ok())
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())
@@ -2075,6 +2211,29 @@ fn snapshot_block_stmts(node: Node, source: &[u8]) -> Vec<DeferredCall> {
         }
     }
     out
+}
+
+fn split_condition_clause<'a>(cond: Node<'a>) -> (Option<Node<'a>>, Option<Node<'a>>) {
+    if cond.kind() != "condition_clause" {
+        return (None, Some(cond));
+    }
+    let init = cond.child_by_field_name("initializer");
+    let value = cond.child_by_field_name("value").or_else(|| {
+        // Fallback: last named child that is not the initializer.
+        let mut last = None;
+        let mut c = cond.walk();
+        for ch in cond.children(&mut c) {
+            if !ch.is_named() {
+                continue;
+            }
+            if init.is_some_and(|i| i.id() == ch.id()) {
+                continue;
+            }
+            last = Some(ch);
+        }
+        last
+    });
+    (init, value)
 }
 
 fn is_switch_default_case(case: Node, source: &[u8]) -> bool {
@@ -3675,10 +3834,15 @@ int abs_val(int x) {
 "#;
         let cfg = build_cfg_for_function("cpp", code, "abs_val").unwrap();
         assert!(cfg.blocks.len() >= 4);
+        assert!(cfg
+            .edges
+            .iter()
+            .any(|e| e.edge_type == CfgEdgeType::IfTrue));
     }
 
     #[test]
     fn test_cpp_range_for_has_cycle() {
+        // Classic indexed for (kept for regression).
         let code = r#"
 int sum_vec(int* arr, int n) {
     int total = 0;
@@ -3690,6 +3854,298 @@ int sum_vec(int* arr, int n) {
 "#;
         let cfg = build_cfg_for_function("cpp", code, "sum_vec").unwrap();
         assert!(cfg.has_cycle());
+    }
+
+    fn cpp_texts(cfg: &ControlFlowGraph) -> Vec<String> {
+        cfg.blocks
+            .values()
+            .flat_map(|b| b.statements.iter().map(|s| s.text.clone()))
+            .collect()
+    }
+
+    fn cpp_kinds(cfg: &ControlFlowGraph) -> Vec<StatementKind> {
+        cfg.blocks
+            .values()
+            .flat_map(|b| b.statements.iter().map(|s| s.kind))
+            .collect()
+    }
+
+    fn cpp_block_ids(cfg: &ControlFlowGraph, needle: &str) -> Vec<uuid::Uuid> {
+        cfg.blocks
+            .values()
+            .filter(|b| b.statements.iter().any(|s| s.text.contains(needle)))
+            .map(|b| b.id)
+            .collect()
+    }
+
+    #[test]
+    fn test_cpp_short_circuit_and() {
+        let code = r#"
+int sc(bool a, bool b) {
+    if (a && b) {
+        return 1;
+    }
+    return 0;
+}
+"#;
+        let cfg = build_cfg_for_function("cpp", code, "sc").unwrap();
+        let texts = cpp_texts(&cfg);
+        assert!(
+            texts.iter().any(|t| t.trim() == "a"),
+            "&& left must split, got {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t.trim() == "b"),
+            "&& right must split, got {texts:?}"
+        );
+    }
+
+    #[test]
+    fn test_cpp_if_init_before_condition() {
+        let code = r#"
+int demo(int x) {
+    if (int y = x; y > 0) {
+        return y;
+    }
+    return 0;
+}
+"#;
+        let cfg = build_cfg_for_function("cpp", code, "demo").unwrap();
+        let texts = cpp_texts(&cfg);
+        assert!(
+            texts
+                .iter()
+                .any(|t| t.contains("int y = x") || t.contains("y = x")),
+            "C++17 if initializer must appear before condition, got {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t.contains("y > 0") || t.trim() == "y > 0"),
+            "condition value must be its own branch, got {texts:?}"
+        );
+        assert!(
+            !texts.iter().any(|t| t.contains("int y = x; y > 0")),
+            "must not keep whole condition_clause as one blob, got {texts:?}"
+        );
+    }
+
+    #[test]
+    fn test_cpp_switch_init_and_cases() {
+        let code = r#"
+int sw(int x) {
+    switch (int z = x; z) {
+        case 1:
+            return 10;
+        case 2:
+            return 20;
+        default:
+            return 0;
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("cpp", code, "sw").unwrap();
+        let texts = cpp_texts(&cfg);
+        assert!(
+            texts
+                .iter()
+                .any(|t| t.contains("int z = x") || t.contains("z = x")),
+            "switch initializer must appear, got {texts:?}"
+        );
+        assert!(
+            cpp_kinds(&cfg)
+                .iter()
+                .filter(|k| **k == StatementKind::Return)
+                .count()
+                >= 3,
+            "case returns must lower, kinds={:?}",
+            cpp_kinds(&cfg)
+        );
+    }
+
+    #[test]
+    fn test_cpp_switch_fallthrough() {
+        let code = r#"
+int sw(int x) {
+    int y = 0;
+    switch (x) {
+        case 1:
+            y = 10;
+        case 2:
+            y = 20;
+            break;
+        default:
+            return 0;
+    }
+    return y;
+}
+"#;
+        let cfg = build_cfg_for_function("cpp", code, "sw").unwrap();
+        let c1 = cpp_block_ids(&cfg, "y = 10");
+        let c2 = cpp_block_ids(&cfg, "y = 20");
+        assert!(!c1.is_empty() && !c2.is_empty(), "case bodies must lower");
+        assert!(
+            c1.iter().any(|f| {
+                c2.iter().any(|t| {
+                    cfg.edges.iter().any(|e| {
+                        e.from == *f && e.to == *t && e.edge_type == CfgEdgeType::Jump
+                    })
+                })
+            }),
+            "case 1 must fall through into case 2"
+        );
+    }
+
+    #[test]
+    fn test_cpp_for_range_loop() {
+        let code = r#"
+int range_sum(int* a, int n) {
+    int t = 0;
+    for (int v : a) {
+        t += v;
+    }
+    return t;
+}
+"#;
+        let cfg = build_cfg_for_function("cpp", code, "range_sum").unwrap();
+        assert!(cfg.has_cycle(), "range-for must cycle");
+        assert!(
+            cpp_texts(&cfg).iter().any(|t| t.contains("t += v") || t.contains("t+=v")),
+            "body must lower, got {:?}",
+            cpp_texts(&cfg)
+        );
+        assert!(
+            !cpp_texts(&cfg)
+                .iter()
+                .any(|t| t.trim_start().starts_with("for (int v")),
+            "range-for must not stay opaque, got {:?}",
+            cpp_texts(&cfg)
+        );
+    }
+
+    #[test]
+    fn test_cpp_try_catch_throw() {
+        let code = r#"
+int throws() {
+    try {
+        throw 1;
+    } catch (int e) {
+        return e;
+    }
+    return 0;
+}
+"#;
+        let cfg = build_cfg_for_function("cpp", code, "throws").unwrap();
+        assert!(
+            cfg.edges
+                .iter()
+                .any(|e| e.edge_type == CfgEdgeType::Exception),
+            "try/catch needs Exception edge"
+        );
+        assert!(
+            cpp_texts(&cfg).iter().any(|t| t.contains("throw")),
+            "throw must appear, got {:?}",
+            cpp_texts(&cfg)
+        );
+        assert!(
+            cpp_kinds(&cfg)
+                .iter()
+                .any(|k| *k == StatementKind::Return),
+            "catch return must lower"
+        );
+    }
+
+    #[test]
+    fn test_cpp_ternary_branches() {
+        let code = r#"
+int t(int y) {
+    return y ? y : -1;
+}
+"#;
+        let cfg = build_cfg_for_function("cpp", code, "t").unwrap();
+        assert!(
+            cfg.edges
+                .iter()
+                .any(|e| e.edge_type == CfgEdgeType::IfTrue)
+                && cfg
+                    .edges
+                    .iter()
+                    .any(|e| e.edge_type == CfgEdgeType::IfFalse),
+            "ternary must split"
+        );
+        assert!(
+            cpp_texts(&cfg).iter().any(|t| t.trim() == "y"),
+            "ternary condition must lower, got {:?}",
+            cpp_texts(&cfg)
+        );
+    }
+
+    #[test]
+    fn test_cpp_goto_and_label() {
+        let code = r#"
+int g(int x) {
+    if (x < 0) {
+        goto done;
+    }
+    x = x + 1;
+done:
+    return x;
+}
+"#;
+        let cfg = build_cfg_for_function("cpp", code, "g").unwrap();
+        let froms = cpp_block_ids(&cfg, "goto done");
+        assert!(!froms.is_empty(), "goto must appear");
+        assert!(
+            cfg.edges
+                .iter()
+                .any(|e| froms.contains(&e.from) && e.edge_type == CfgEdgeType::Jump),
+            "goto must Jump"
+        );
+    }
+
+    #[test]
+    fn test_cpp_co_await_splits_block() {
+        let code = r#"
+task coro() {
+    co_await something();
+    co_return 1;
+}
+"#;
+        let cfg = build_cfg_for_function("cpp", code, "coro").unwrap();
+        assert!(
+            cpp_texts(&cfg)
+                .iter()
+                .any(|t| t.contains("co_await") || t.contains("await")),
+            "co_await must appear, got {:?}",
+            cpp_texts(&cfg)
+        );
+        assert!(
+            cfg.blocks.len() >= 3,
+            "co_await should split blocks, blocks={}",
+            cfg.blocks.len()
+        );
+        assert!(
+            cpp_texts(&cfg)
+                .iter()
+                .any(|t| t.contains("co_return") || t.contains("return")),
+            "co_return must lower, got {:?}",
+            cpp_texts(&cfg)
+        );
+    }
+
+    #[test]
+    fn test_cpp_co_yield_splits_block() {
+        let code = r#"
+generator gen() {
+    co_yield 1;
+    co_return;
+}
+"#;
+        let cfg = build_cfg_for_function("cpp", code, "gen").unwrap();
+        assert!(
+            cpp_texts(&cfg).iter().any(|t| t.contains("co_yield") || t.contains("yield")),
+            "co_yield must appear, got {:?}",
+            cpp_texts(&cfg)
+        );
+        assert!(cfg.blocks.len() >= 3, "co_yield should split blocks");
     }
 
     #[test]

--- a/crates/rbuilder-analysis/src/cfg_builder.rs
+++ b/crates/rbuilder-analysis/src/cfg_builder.rs
@@ -148,14 +148,33 @@ struct CfgBuilder<'a> {
     cfg: &'a mut ControlFlowGraph,
     current_block: BlockId,
     language: &'a str,
-    loop_stack: Vec<LoopContext>,
+    /// Innermost-first stack of `for` / `switch` / `select` break targets.
+    breakable_stack: Vec<BreakableContext>,
     /// False after return/unreachable branch terminates the current path.
     flow_active: bool,
+    /// Go `Label:` entry blocks (created eagerly so forward `goto` resolves).
+    label_blocks: HashMap<String, BlockId>,
+    /// Set when the current switch case ended with `fallthrough`.
+    pending_fallthrough: bool,
+    /// Label to attach to the next pushed breakable (`Outer: for` / `Outer: switch`).
+    pending_breakable_label: Option<String>,
+    /// Function-scoped `defer` stack (static approx; LIFO on return/panic).
+    defer_stack: Vec<DeferredCall>,
 }
 
-struct LoopContext {
-    header: BlockId,
+struct BreakableContext {
+    /// Block after the loop/switch/select.
     exit: BlockId,
+    /// `continue` target (update/header). `None` for switch/select.
+    continue_target: Option<BlockId>,
+    /// Optional label from `Label: for` / `Label: switch`.
+    label: Option<String>,
+}
+
+#[derive(Clone)]
+struct DeferredCall {
+    text: String,
+    line: usize,
 }
 
 impl<'a> CfgBuilder<'a> {
@@ -165,8 +184,12 @@ impl<'a> CfgBuilder<'a> {
             cfg,
             current_block: entry,
             language,
-            loop_stack: Vec::new(),
+            breakable_stack: Vec::new(),
             flow_active: true,
+            label_blocks: HashMap::new(),
+            pending_fallthrough: false,
+            pending_breakable_label: None,
+            defer_stack: Vec::new(),
         }
     }
 
@@ -178,11 +201,15 @@ impl<'a> CfgBuilder<'a> {
                 message: "Function has no body".to_string(),
             })?;
         self.visit_block(body, source)?;
-        if self.flow_active && self.cfg.exits.is_empty() {
-            let exit = self.new_block();
-            self.cfg
-                .add_edge(self.current_block, exit, CfgEdgeType::Next);
-            self.cfg.exits.push(exit);
+        if self.flow_active {
+            if !self.defer_stack.is_empty() {
+                self.unwind_defers_to_exit(CfgEdgeType::Return);
+            } else if self.cfg.exits.is_empty() {
+                let exit = self.new_block();
+                self.cfg
+                    .add_edge(self.current_block, exit, CfgEdgeType::Next);
+                self.cfg.exits.push(exit);
+            }
         }
         self.cfg.prune_unreachable_blocks();
         Ok(())
@@ -262,6 +289,11 @@ impl<'a> CfgBuilder<'a> {
             // Jumps
             "break_expression" | "break_statement" => self.visit_break(node, source),
             "continue_expression" | "continue_statement" => self.visit_continue(node, source),
+            "goto_statement" => self.visit_goto(node, source),
+            "fallthrough_statement" => self.visit_fallthrough(node, source),
+            "labeled_statement" | "empty_labeled_statement" => {
+                self.visit_labeled_statement(node, source)
+            }
 
             // Declarations / assignments
             "let_declaration" | "let_statement" => {
@@ -286,6 +318,10 @@ impl<'a> CfgBuilder<'a> {
                 self.add_statement(node, source, StatementKind::Assignment)?;
                 Ok(())
             }
+            "inc_statement" | "dec_statement" | "send_statement" => {
+                self.add_statement(node, source, StatementKind::Expression)?;
+                Ok(())
+            }
 
             // Expression statement
             "expression_statement" => self.visit_expression_stmt(node, source),
@@ -299,8 +335,9 @@ impl<'a> CfgBuilder<'a> {
             }
             "select_statement" => self.visit_select(node, source),
 
-            // Go concurrency helpers (sequential approximation)
-            "defer_statement" | "go_statement" => {
+            // Go concurrency helpers
+            "defer_statement" => self.visit_defer(node, source),
+            "go_statement" => {
                 self.add_statement(node, source, StatementKind::Expression)?;
                 Ok(())
             }
@@ -334,7 +371,11 @@ impl<'a> CfgBuilder<'a> {
             }
             _ => {
                 let kind = Self::classify_expression(inner, source);
-                self.add_statement(inner, source, kind)
+                self.add_statement(inner, source, kind)?;
+                if is_panic_call(inner, source) {
+                    self.unwind_defers_to_exit(CfgEdgeType::Exception);
+                }
+                Ok(())
             }
         }
     }
@@ -355,58 +396,78 @@ impl<'a> CfgBuilder<'a> {
     }
 
     fn visit_if(&mut self, node: Node, source: &[u8]) -> Result<()> {
-        self.add_statement(node, source, StatementKind::Branch)?;
-        let cond_block = self.current_block;
-
-        let cond_text = node
-            .child_by_field_name("condition")
-            .or_else(|| node.child_by_field_name("operand"))
-            .and_then(|c| c.utf8_text(source).ok())
-            .unwrap_or("")
-            .trim()
-            .to_string();
-
-        let true_block = self.new_block();
-        self.cfg
-            .add_edge(cond_block, true_block, CfgEdgeType::IfTrue);
-
-        let false_block = self.new_block();
-        self.cfg
-            .add_edge(cond_block, false_block, CfgEdgeType::IfFalse);
-
-        let mut true_end = true_block;
-        if !is_constant_false(&cond_text) {
-            self.current_block = true_block;
-            if let Some(consequence) = node
-                .child_by_field_name("consequence")
-                .or_else(|| node.child_by_field_name("body"))
-            {
-                self.visit_block(consequence, source)?;
-            }
-            true_end = self.current_block;
+        // Go: `if init; cond` — init runs in the current block before the condition.
+        if let Some(init) = node.child_by_field_name("initializer") {
+            self.visit_statement(init, source)?;
         }
 
+        let cond_block = self.new_block();
+        self.cfg
+            .add_edge(self.current_block, cond_block, CfgEdgeType::Next);
+        self.current_block = cond_block;
+
+        let true_block = self.new_block();
+        let false_block = self.new_block();
+
+        if let Some(cond) = node
+            .child_by_field_name("condition")
+            .or_else(|| node.child_by_field_name("operand"))
+        {
+            self.wire_condition(cond, source, true_block, false_block)?;
+        } else {
+            self.add_statement_to_current(Statement {
+                kind: StatementKind::Branch,
+                line: node.start_position().row + 1,
+                text: "if".to_string(),
+                defined_vars: HashSet::new(),
+                used_vars: HashSet::new(),
+            });
+            self.cfg
+                .add_edge(cond_block, true_block, CfgEdgeType::IfTrue);
+            self.cfg
+                .add_edge(cond_block, false_block, CfgEdgeType::IfFalse);
+        }
+
+        let true_end;
+        let true_reaches;
+        self.flow_active = true;
+        self.current_block = true_block;
+        if let Some(consequence) = node
+            .child_by_field_name("consequence")
+            .or_else(|| node.child_by_field_name("body"))
+        {
+            self.visit_block(consequence, source)?;
+        }
+        true_end = self.current_block;
+        true_reaches = self.flow_active;
+
         let mut false_end = false_block;
+        let false_reaches;
+        self.flow_active = true;
         self.current_block = false_block;
-        if !is_constant_true(&cond_text) {
-            if let Some(alternative) = node
-                .child_by_field_name("alternative")
-                .or_else(|| node.child_by_field_name("else"))
-            {
-                self.visit_block(alternative, source)?;
-            } else if let Some(else_clause) = node.child_by_field_name("else_clause") {
-                self.visit_block(else_clause, source)?;
-            }
+        if let Some(alternative) = node
+            .child_by_field_name("alternative")
+            .or_else(|| node.child_by_field_name("else"))
+        {
+            self.visit_block(alternative, source)?;
             false_end = self.current_block;
+            false_reaches = self.flow_active;
+        } else if let Some(else_clause) = node.child_by_field_name("else_clause") {
+            self.visit_block(else_clause, source)?;
+            false_end = self.current_block;
+            false_reaches = self.flow_active;
+        } else {
+            false_reaches = true;
         }
 
         let merge = self.new_block();
-        if !is_constant_false(&cond_text) {
+        if true_reaches {
             self.cfg.add_edge(true_end, merge, CfgEdgeType::Next);
         }
-        if !is_constant_true(&cond_text) {
+        if false_reaches {
             self.cfg.add_edge(false_end, merge, CfgEdgeType::Next);
         }
+        self.flow_active = true_reaches || false_reaches;
         self.current_block = merge;
         Ok(())
     }
@@ -433,7 +494,11 @@ impl<'a> CfgBuilder<'a> {
         let exit = self.new_block();
         self.cfg.add_edge(header, exit, CfgEdgeType::IfFalse);
 
-        self.loop_stack.push(LoopContext { header, exit });
+        self.breakable_stack.push(BreakableContext {
+            exit,
+            continue_target: Some(header),
+            label: self.pending_breakable_label.take(),
+        });
 
         self.current_block = body;
         if let Some(body_node) = node.child_by_field_name("body") {
@@ -441,7 +506,7 @@ impl<'a> CfgBuilder<'a> {
         }
         self.cfg
             .add_edge(self.current_block, header, CfgEdgeType::Jump);
-        self.loop_stack.pop();
+        self.breakable_stack.pop();
 
         self.current_block = exit;
         Ok(())
@@ -455,7 +520,11 @@ impl<'a> CfgBuilder<'a> {
         let header = self.new_block();
         let exit = self.new_block();
 
-        self.loop_stack.push(LoopContext { header, exit });
+        self.breakable_stack.push(BreakableContext {
+            exit,
+            continue_target: Some(header),
+            label: self.pending_breakable_label.take(),
+        });
 
         self.current_block = body;
         if let Some(body_node) = node.child_by_field_name("body") {
@@ -478,46 +547,120 @@ impl<'a> CfgBuilder<'a> {
         });
         self.cfg.add_edge(header, body, CfgEdgeType::IfTrue);
         self.cfg.add_edge(header, exit, CfgEdgeType::IfFalse);
-        self.loop_stack.pop();
+        self.breakable_stack.pop();
 
         self.current_block = exit;
         Ok(())
     }
 
     fn visit_for(&mut self, node: Node, source: &[u8]) -> Result<()> {
-        if let Some(init) = node
-            .child_by_field_name("initializer")
-            .or_else(|| node.child_by_field_name("range"))
-        {
+        // Language-specific loop header pieces (Go for_clause / range_clause, C-like initializer).
+        let mut for_clause = None;
+        let mut range_clause = None;
+        let mut while_cond = None;
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            match child.kind() {
+                "for_clause" => for_clause = Some(child),
+                "range_clause" => range_clause = Some(child),
+                k if while_cond.is_none()
+                    && child.is_named()
+                    && k != "block"
+                    && !is_block_like(k)
+                    && k != "for_clause"
+                    && k != "range_clause" =>
+                {
+                    // while-style `for cond { }` — bare condition expression child
+                    while_cond = Some(child);
+                }
+                _ => {}
+            }
+        }
+
+        if let Some(clause) = for_clause {
+            if let Some(init) = clause.child_by_field_name("initializer") {
+                self.visit_statement(init, source)?;
+            }
+        } else if let Some(init) = node.child_by_field_name("initializer") {
             self.visit_statement(init, source)?;
+        } else if let Some(range) = range_clause {
+            self.add_statement(range, source, StatementKind::Expression)?;
         }
 
         let header = self.new_block();
         self.cfg
             .add_edge(self.current_block, header, CfgEdgeType::Next);
-        self.add_statement_to_current(Statement {
-            kind: StatementKind::Branch,
-            line: node.start_position().row + 1,
-            text: "for".to_string(),
-            defined_vars: HashSet::new(),
-            used_vars: HashSet::new(),
-        });
+        self.current_block = header;
 
         let body = self.new_block();
-        self.cfg.add_edge(header, body, CfgEdgeType::IfTrue);
         let exit = self.new_block();
-        self.cfg.add_edge(header, exit, CfgEdgeType::IfFalse);
 
-        self.loop_stack.push(LoopContext { header, exit });
+        let cond_node = for_clause
+            .and_then(|c| c.child_by_field_name("condition"))
+            .or(while_cond)
+            .or_else(|| node.child_by_field_name("condition"));
 
+        if let Some(cond) = cond_node {
+            self.wire_condition(cond, source, body, exit)?;
+        } else {
+            let cond_text = if let Some(range) = range_clause {
+                range
+                    .utf8_text(source)
+                    .ok()
+                    .map(|s| s.trim().to_string())
+                    .unwrap_or_else(|| "range".to_string())
+            } else {
+                "true".to_string()
+            };
+            self.add_statement_to_current(Statement {
+                kind: StatementKind::Branch,
+                line: node.start_position().row + 1,
+                text: cond_text,
+                defined_vars: HashSet::new(),
+                used_vars: HashSet::new(),
+            });
+            self.cfg.add_edge(header, body, CfgEdgeType::IfTrue);
+            self.cfg.add_edge(header, exit, CfgEdgeType::IfFalse);
+        }
+
+        let update_block = if let Some(clause) = for_clause {
+            clause.child_by_field_name("update").map(|update_node| {
+                let update_block = self.new_block();
+                (update_block, update_node)
+            })
+        } else {
+            None
+        };
+
+        let continue_target = update_block.map(|(id, _)| id).unwrap_or(header);
+        self.breakable_stack.push(BreakableContext {
+            exit,
+            continue_target: Some(continue_target),
+            label: self.pending_breakable_label.take(),
+        });
+
+        self.flow_active = true;
         self.current_block = body;
         if let Some(body_node) = node.child_by_field_name("body") {
             self.visit_block(body_node, source)?;
         }
-        self.cfg
-            .add_edge(self.current_block, header, CfgEdgeType::Jump);
-        self.loop_stack.pop();
+        if self.flow_active {
+            self.cfg
+                .add_edge(self.current_block, continue_target, CfgEdgeType::Jump);
+        }
 
+        if let Some((update_id, update_node)) = update_block {
+            self.flow_active = true;
+            self.current_block = update_id;
+            self.visit_statement(update_node, source)?;
+            if self.flow_active {
+                self.cfg
+                    .add_edge(self.current_block, header, CfgEdgeType::Next);
+            }
+        }
+
+        self.breakable_stack.pop();
+        self.flow_active = true;
         self.current_block = exit;
         Ok(())
     }
@@ -531,7 +674,11 @@ impl<'a> CfgBuilder<'a> {
         let exit = self.new_block();
         self.cfg.add_edge(header, exit, CfgEdgeType::IfFalse);
 
-        self.loop_stack.push(LoopContext { header, exit });
+        self.breakable_stack.push(BreakableContext {
+            exit,
+            continue_target: Some(header),
+            label: self.pending_breakable_label.take(),
+        });
 
         self.current_block = body;
         if let Some(body_node) = node.child_by_field_name("body") {
@@ -539,7 +686,7 @@ impl<'a> CfgBuilder<'a> {
         }
         self.cfg
             .add_edge(self.current_block, header, CfgEdgeType::Jump);
-        self.loop_stack.pop();
+        self.breakable_stack.pop();
 
         self.current_block = exit;
         Ok(())
@@ -547,31 +694,281 @@ impl<'a> CfgBuilder<'a> {
 
     fn visit_return(&mut self, node: Node, source: &[u8]) -> Result<()> {
         self.add_statement(node, source, StatementKind::Return)?;
+        self.unwind_defers_to_exit(CfgEdgeType::Return);
+        Ok(())
+    }
+
+    fn visit_defer(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        self.add_statement(node, source, StatementKind::Expression)?;
+        let deferred = node
+            .named_child(0)
+            .and_then(|n| n.utf8_text(source).ok())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| {
+                node.utf8_text(source)
+                    .unwrap_or("defer")
+                    .trim()
+                    .trim_start_matches("defer")
+                    .trim()
+                    .to_string()
+            });
+        self.defer_stack.push(DeferredCall {
+            text: deferred,
+            line: node.start_position().row + 1,
+        });
+        Ok(())
+    }
+
+    /// Route current block through deferred calls (LIFO) then a terminal exit edge.
+    fn unwind_defers_to_exit(&mut self, terminal: CfgEdgeType) {
+        let deferred: Vec<_> = self.defer_stack.iter().rev().cloned().collect();
+        let mut prev = self.current_block;
+        for d in deferred {
+            let b = self.new_block();
+            self.cfg.add_edge(prev, b, CfgEdgeType::Next);
+            self.current_block = b;
+            self.add_statement_to_current(Statement {
+                kind: StatementKind::FunctionCall,
+                line: d.line,
+                text: d.text,
+                defined_vars: HashSet::new(),
+                used_vars: HashSet::new(),
+            });
+            prev = b;
+        }
         let exit = self.new_block();
-        self.cfg
-            .add_edge(self.current_block, exit, CfgEdgeType::Return);
+        self.cfg.add_edge(prev, exit, terminal);
         self.cfg.exits.push(exit);
         self.flow_active = false;
-        Ok(())
+    }
+
+    fn jump_label_of(node: Node, source: &[u8]) -> Option<String> {
+        let mut c = node.walk();
+        for ch in node.children(&mut c) {
+            if ch.kind() == "label_name" {
+                return ch.utf8_text(source).ok().map(|s| s.trim().to_string());
+            }
+        }
+        // `break Outer` — second named child may be the label
+        if let Some(n) = node.named_child(0) {
+            if n.kind() == "label_name" || n.kind() == "identifier" {
+                return n.utf8_text(source).ok().map(|s| s.trim().to_string());
+            }
+        }
+        None
+    }
+
+    fn find_breakable(&self, label: Option<&str>) -> Option<&BreakableContext> {
+        match label {
+            Some(l) => self
+                .breakable_stack
+                .iter()
+                .rev()
+                .find(|c| c.label.as_deref() == Some(l)),
+            None => self.breakable_stack.last(),
+        }
     }
 
     fn visit_break(&mut self, node: Node, source: &[u8]) -> Result<()> {
         self.add_statement(node, source, StatementKind::Jump)?;
-        if let Some(ctx) = self.loop_stack.last() {
+        let label = Self::jump_label_of(node, source);
+        if let Some(ctx) = self.find_breakable(label.as_deref()) {
+            let exit = ctx.exit;
             self.cfg
-                .add_edge(self.current_block, ctx.exit, CfgEdgeType::Jump);
+                .add_edge(self.current_block, exit, CfgEdgeType::Jump);
         }
+        self.flow_active = false;
         self.current_block = self.new_block();
         Ok(())
     }
 
     fn visit_continue(&mut self, node: Node, source: &[u8]) -> Result<()> {
         self.add_statement(node, source, StatementKind::Jump)?;
-        if let Some(ctx) = self.loop_stack.last() {
-            self.cfg
-                .add_edge(self.current_block, ctx.header, CfgEdgeType::Jump);
+        let label = Self::jump_label_of(node, source);
+        if let Some(ctx) = self.find_breakable(label.as_deref()) {
+            if let Some(cont) = ctx.continue_target {
+                self.cfg
+                    .add_edge(self.current_block, cont, CfgEdgeType::Jump);
+            }
         }
+        self.flow_active = false;
         self.current_block = self.new_block();
+        Ok(())
+    }
+
+    fn ensure_label_block(&mut self, name: &str) -> BlockId {
+        if let Some(id) = self.label_blocks.get(name) {
+            return *id;
+        }
+        let id = self.new_block();
+        self.label_blocks.insert(name.to_string(), id);
+        id
+    }
+
+    fn visit_goto(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        self.add_statement(node, source, StatementKind::Jump)?;
+        let label = {
+            let mut found = None;
+            if let Some(n) = node.named_child(0) {
+                found = n.utf8_text(source).ok().map(|s| s.trim().to_string());
+            }
+            if found.is_none() {
+                let mut c = node.walk();
+                for ch in node.children(&mut c) {
+                    if ch.kind() == "label_name" {
+                        found = ch.utf8_text(source).ok().map(|s| s.trim().to_string());
+                        break;
+                    }
+                }
+            }
+            found.unwrap_or_default()
+        };
+        if !label.is_empty() {
+            let target = self.ensure_label_block(&label);
+            self.cfg
+                .add_edge(self.current_block, target, CfgEdgeType::Jump);
+        }
+        self.flow_active = false;
+        self.current_block = self.new_block();
+        Ok(())
+    }
+
+    fn visit_fallthrough(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        self.add_statement(node, source, StatementKind::Jump)?;
+        self.pending_fallthrough = true;
+        self.flow_active = false;
+        Ok(())
+    }
+
+    fn visit_labeled_statement(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        let label = node
+            .child_by_field_name("label")
+            .and_then(|n| n.utf8_text(source).ok())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if label.is_empty() {
+            return Ok(());
+        }
+        let label_block = self.ensure_label_block(&label);
+        if self.flow_active {
+            self.cfg
+                .add_edge(self.current_block, label_block, CfgEdgeType::Next);
+        }
+        self.current_block = label_block;
+        self.flow_active = true;
+
+        // `label: stmt` — visit the statement after the label (skip label_name).
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if !child.is_named() {
+                continue;
+            }
+            if child.kind() == "label_name" {
+                continue;
+            }
+            if node.child_by_field_name("label").is_some_and(|l| l.id() == child.id()) {
+                continue;
+            }
+            let attach_label = matches!(
+                child.kind(),
+                "for_statement"
+                    | "for_expression"
+                    | "while_statement"
+                    | "while_expression"
+                    | "do_statement"
+                    | "loop_expression"
+                    | "switch_statement"
+                    | "type_switch_statement"
+                    | "expression_switch_statement"
+                    | "select_statement"
+            );
+            if attach_label {
+                self.pending_breakable_label = Some(label.clone());
+            }
+            self.visit_statement(child, source)?;
+            if attach_label {
+                self.pending_breakable_label = None;
+            }
+        }
+        Ok(())
+    }
+
+    /// Lower `&&` / `||` into short-circuit CFG edges ending at `true_dest` / `false_dest`.
+    fn wire_condition(
+        &mut self,
+        cond: Node,
+        source: &[u8],
+        true_dest: BlockId,
+        false_dest: BlockId,
+    ) -> Result<()> {
+        if let Some(op) = logical_operator(cond, source) {
+            let left = cond
+                .child_by_field_name("left")
+                .ok_or_else(|| Error::ParseError {
+                    file: "source".into(),
+                    line: cond.start_position().row + 1,
+                    message: "logical expression missing left".into(),
+                })?;
+            let right = cond
+                .child_by_field_name("right")
+                .ok_or_else(|| Error::ParseError {
+                    file: "source".into(),
+                    line: cond.start_position().row + 1,
+                    message: "logical expression missing right".into(),
+                })?;
+            let mid = self.new_block();
+            if op == "&&" {
+                self.wire_condition(left, source, mid, false_dest)?;
+                self.flow_active = true;
+                self.current_block = mid;
+                self.wire_condition(right, source, true_dest, false_dest)?;
+            } else {
+                self.wire_condition(left, source, true_dest, mid)?;
+                self.flow_active = true;
+                self.current_block = mid;
+                self.wire_condition(right, source, true_dest, false_dest)?;
+            }
+            return Ok(());
+        }
+
+        let text = cond.utf8_text(source)?.trim().to_string();
+        if is_constant_false(&text) {
+            self.add_statement_to_current(Statement {
+                kind: StatementKind::Branch,
+                line: cond.start_position().row + 1,
+                text,
+                defined_vars: HashSet::new(),
+                used_vars: HashSet::new(),
+            });
+            self.cfg
+                .add_edge(self.current_block, false_dest, CfgEdgeType::IfFalse);
+            return Ok(());
+        }
+        if is_constant_true(&text) {
+            self.add_statement_to_current(Statement {
+                kind: StatementKind::Branch,
+                line: cond.start_position().row + 1,
+                text,
+                defined_vars: HashSet::new(),
+                used_vars: HashSet::new(),
+            });
+            self.cfg
+                .add_edge(self.current_block, true_dest, CfgEdgeType::IfTrue);
+            return Ok(());
+        }
+
+        self.add_statement_to_current(Statement {
+            kind: StatementKind::Branch,
+            line: cond.start_position().row + 1,
+            text,
+            defined_vars: HashSet::new(),
+            used_vars: HashSet::new(),
+        });
+        let from = self.current_block;
+        self.cfg.add_edge(from, true_dest, CfgEdgeType::IfTrue);
+        self.cfg.add_edge(from, false_dest, CfgEdgeType::IfFalse);
         Ok(())
     }
 
@@ -614,9 +1011,47 @@ impl<'a> CfgBuilder<'a> {
     }
 
     fn visit_switch(&mut self, node: Node, source: &[u8]) -> Result<()> {
-        self.add_statement(node, source, StatementKind::Branch)?;
-        let cond_block = self.current_block;
+        // Go: `switch init; value` — init runs before the branch.
+        if let Some(init) = node.child_by_field_name("initializer") {
+            self.visit_statement(init, source)?;
+        } else {
+            // type_switch_statement nests initializer under the header child.
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if let Some(init) = child.child_by_field_name("initializer") {
+                    self.visit_statement(init, source)?;
+                    break;
+                }
+            }
+        }
+
+        let cond_block = self.new_block();
+        self.cfg
+            .add_edge(self.current_block, cond_block, CfgEdgeType::Next);
+        self.current_block = cond_block;
+
+        let branch_text = node
+            .child_by_field_name("value")
+            .or_else(|| node.child_by_field_name("condition"))
+            .or_else(|| node.child_by_field_name("operand"))
+            .and_then(|c| c.utf8_text(source).ok())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| node.kind().to_string());
+        self.add_statement_to_current(Statement {
+            kind: StatementKind::Branch,
+            line: node.start_position().row + 1,
+            text: branch_text,
+            defined_vars: HashSet::new(),
+            used_vars: HashSet::new(),
+        });
+
         let merge = self.new_block();
+        self.breakable_stack.push(BreakableContext {
+            exit: merge,
+            continue_target: None,
+            label: self.pending_breakable_label.take(),
+        });
         let mut cases = Vec::new();
         collect_switch_cases(node, &mut cases);
 
@@ -625,11 +1060,15 @@ impl<'a> CfgBuilder<'a> {
                 self.current_block = cond_block;
                 self.visit_block(body, source)?;
             }
+            self.breakable_stack.pop();
             self.current_block = merge;
+            self.flow_active = true;
             return Ok(());
         }
 
         let mut has_default = false;
+        let mut any_reaches_merge = false;
+        let mut fallthrough_from: Option<BlockId> = None;
         for case in cases {
             let is_default = matches!(
                 case.kind(),
@@ -646,15 +1085,21 @@ impl<'a> CfgBuilder<'a> {
                 CfgEdgeType::IfTrue
             };
             self.cfg.add_edge(cond_block, case_block, edge);
-            self.current_block = case_block;
-
-            if let Some(body) = case.child_by_field_name("body") {
-                self.visit_block(body, source)?;
-            } else {
-                self.visit_block(case, source)?;
+            if let Some(src) = fallthrough_from.take() {
+                self.cfg.add_edge(src, case_block, CfgEdgeType::Jump);
             }
-            self.cfg
-                .add_edge(self.current_block, merge, CfgEdgeType::Next);
+            self.flow_active = true;
+            self.pending_fallthrough = false;
+            self.current_block = case_block;
+            self.visit_case_body(case, source)?;
+            if self.pending_fallthrough {
+                fallthrough_from = Some(self.current_block);
+                self.pending_fallthrough = false;
+            } else if self.flow_active {
+                self.cfg
+                    .add_edge(self.current_block, merge, CfgEdgeType::Next);
+                any_reaches_merge = true;
+            }
         }
 
         if !has_default {
@@ -662,9 +1107,27 @@ impl<'a> CfgBuilder<'a> {
             self.cfg
                 .add_edge(cond_block, default_block, CfgEdgeType::IfFalse);
             self.cfg.add_edge(default_block, merge, CfgEdgeType::Next);
+            any_reaches_merge = true;
         }
 
+        self.breakable_stack.pop();
+        self.flow_active = any_reaches_merge;
         self.current_block = merge;
+        Ok(())
+    }
+
+    /// Lower switch/select case bodies (Go uses `statement_list`, others may use `body`).
+    fn visit_case_body(&mut self, case: Node, source: &[u8]) -> Result<()> {
+        if let Some(body) = case.child_by_field_name("body") {
+            self.visit_block(body, source)?;
+            return Ok(());
+        }
+        let mut cursor = case.walk();
+        for child in case.children(&mut cursor) {
+            if child.kind() == "statement_list" || is_block_like(child.kind()) {
+                self.visit_block(child, source)?;
+            }
+        }
         Ok(())
     }
 
@@ -787,6 +1250,32 @@ fn is_constant_true(text: &str) -> bool {
     matches!(text, "true" | "True" | "1")
 }
 
+fn is_panic_call(node: Node, source: &[u8]) -> bool {
+    let call = if node.kind() == "call_expression" {
+        node
+    } else {
+        return false;
+    };
+    let func = call
+        .child_by_field_name("function")
+        .or_else(|| call.named_child(0));
+    func.and_then(|f| f.utf8_text(source).ok())
+        .is_some_and(|s| s.trim() == "panic")
+}
+
+fn logical_operator<'a>(node: Node<'a>, source: &'a [u8]) -> Option<&'a str> {
+    if node.kind() != "binary_expression" {
+        return None;
+    }
+    let op = node.child_by_field_name("operator")?;
+    let text = op.utf8_text(source).ok()?;
+    if text == "&&" || text == "||" {
+        Some(text)
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -878,6 +1367,523 @@ func Sum(n int) int {
 "#;
         let cfg = build_cfg_for_function("go", code, "Sum").unwrap();
         assert!(cfg.has_cycle());
+    }
+
+    fn go_stmt_texts(cfg: &ControlFlowGraph) -> Vec<String> {
+        let mut out = Vec::new();
+        for b in cfg.blocks.values() {
+            for s in &b.statements {
+                out.push(s.text.clone());
+            }
+        }
+        out
+    }
+
+    fn go_stmt_kinds(cfg: &ControlFlowGraph) -> Vec<StatementKind> {
+        let mut out = Vec::new();
+        for b in cfg.blocks.values() {
+            for s in &b.statements {
+                out.push(s.kind);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn test_go_if_initializer_before_condition() {
+        let code = r#"
+package demo
+
+func IfInit(err error) int {
+    if e := err; e != nil {
+        return 1
+    }
+    return 0
+}
+"#;
+        let cfg = build_cfg_for_function("go", code, "IfInit").unwrap();
+        let texts = go_stmt_texts(&cfg);
+        assert!(
+            texts.iter().any(|t| t.contains("e := err") || t.contains("e:=err")),
+            "if initializer must be its own CFG statement, got {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t.contains("e != nil") || t.contains("e!=nil")),
+            "condition should appear as branch text, got {texts:?}"
+        );
+        assert!(
+            !texts.iter().any(|t| t.trim_start().starts_with("if e :=")),
+            "whole if_statement should not be one Branch blob, got {texts:?}"
+        );
+        assert!(
+            cfg.edges
+                .iter()
+                .any(|e| e.edge_type == CfgEdgeType::Return),
+            "return in then-branch must create Return edge"
+        );
+    }
+
+    #[test]
+    fn test_go_for_clause_init_cond_update_and_continue() {
+        let code = r#"
+package demo
+
+func Sum(n int) int {
+    total := 0
+    for i := 0; i < n; i++ {
+        if i == 1 {
+            continue
+        }
+        total += i
+    }
+    return total
+}
+"#;
+        let cfg = build_cfg_for_function("go", code, "Sum").unwrap();
+        let texts = go_stmt_texts(&cfg);
+        assert!(
+            texts.iter().any(|t| t.contains("i := 0") || t.contains("i:=0")),
+            "for init must be visited, got {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t.contains("i < n") || t.contains("i<n")),
+            "for condition must be header branch, got {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t.contains("i++")),
+            "for update must appear, got {texts:?}"
+        );
+        assert!(cfg.has_cycle(), "for must still cycle");
+
+        // continue must target update (or a block that reaches update), not skip update forever.
+        let continue_blocks: Vec<_> = cfg
+            .blocks
+            .values()
+            .filter(|b| {
+                b.statements
+                    .iter()
+                    .any(|s| s.kind == StatementKind::Jump && s.text.contains("continue"))
+            })
+            .collect();
+        assert!(!continue_blocks.is_empty(), "expected continue statement");
+        let update_blocks: Vec<_> = cfg
+            .blocks
+            .values()
+            .filter(|b| b.statements.iter().any(|s| s.text.contains("i++")))
+            .map(|b| b.id)
+            .collect();
+        assert!(!update_blocks.is_empty());
+        let mut reaches_update = false;
+        for b in &continue_blocks {
+            for e in &cfg.edges {
+                if e.from == b.id && update_blocks.contains(&e.to) {
+                    reaches_update = true;
+                }
+            }
+        }
+        assert!(
+            reaches_update,
+            "continue must jump to update block containing i++"
+        );
+    }
+
+    #[test]
+    fn test_go_switch_case_bodies_emit_returns() {
+        let code = r#"
+package demo
+
+func Pick(x int) int {
+    switch x {
+    case 1:
+        return 10
+    case 2:
+        return 20
+    default:
+        return 0
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("go", code, "Pick").unwrap();
+        let kinds = go_stmt_kinds(&cfg);
+        assert!(
+            kinds.iter().filter(|k| **k == StatementKind::Return).count() >= 3,
+            "each case return must be a Return statement, got {kinds:?}"
+        );
+        let returns = cfg
+            .edges
+            .iter()
+            .filter(|e| e.edge_type == CfgEdgeType::Return)
+            .count();
+        assert!(
+            returns >= 3,
+            "expected Return edges from case bodies, got {returns}"
+        );
+        assert!(
+            !go_stmt_texts(&cfg)
+                .iter()
+                .any(|t| t.trim_start().starts_with("case 1:")),
+            "case arms must not remain opaque Expression blobs"
+        );
+    }
+
+    #[test]
+    fn test_go_switch_initializer_visited() {
+        let code = r#"
+package demo
+
+func Pick(err error) int {
+    switch e := err; e {
+    case nil:
+        return 0
+    default:
+        return 1
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("go", code, "Pick").unwrap();
+        let texts = go_stmt_texts(&cfg);
+        assert!(
+            texts.iter().any(|t| t.contains("e := err") || t.contains("e:=err")),
+            "switch initializer must be visited, got {texts:?}"
+        );
+        assert!(
+            go_stmt_kinds(&cfg)
+                .iter()
+                .any(|k| *k == StatementKind::Return),
+            "case body returns must be lowered"
+        );
+    }
+
+    fn block_ids_containing(cfg: &ControlFlowGraph, needle: &str) -> Vec<uuid::Uuid> {
+        cfg.blocks
+            .values()
+            .filter(|b| b.statements.iter().any(|s| s.text.contains(needle)))
+            .map(|b| b.id)
+            .collect()
+    }
+
+    fn has_edge_from_text_to_text(
+        cfg: &ControlFlowGraph,
+        from_needle: &str,
+        to_needle: &str,
+    ) -> bool {
+        let froms = block_ids_containing(cfg, from_needle);
+        let tos = block_ids_containing(cfg, to_needle);
+        cfg.edges.iter().any(|e| {
+            froms.contains(&e.from)
+                && tos.contains(&e.to)
+                && matches!(e.edge_type, CfgEdgeType::Jump | CfgEdgeType::Next)
+        })
+    }
+
+    #[test]
+    fn test_go_fallthrough_edges_to_next_case() {
+        let code = r#"
+package demo
+
+func Ft(x int) int {
+    switch x {
+    case 1:
+        x = x + 1
+        fallthrough
+    case 2:
+        return x
+    default:
+        return 0
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("go", code, "Ft").unwrap();
+        assert!(
+            go_stmt_texts(&cfg).iter().any(|t| t.contains("fallthrough")),
+            "fallthrough must be a CFG statement"
+        );
+        assert!(
+            has_edge_from_text_to_text(&cfg, "fallthrough", "return x")
+                || has_edge_from_text_to_text(&cfg, "x = x + 1", "return x"),
+            "fallthrough must connect case 1 body into case 2 body, edges={:?}",
+            cfg.edges
+                .iter()
+                .map(|e| format!("{:?}", e.edge_type))
+                .collect::<Vec<_>>()
+        );
+        // Case 1 must not only merge-exit past case 2 without a jump into it.
+        let ft_blocks = block_ids_containing(&cfg, "fallthrough");
+        let merge_only = cfg.edges.iter().any(|e| {
+            ft_blocks.contains(&e.from) && e.edge_type == CfgEdgeType::Next
+        });
+        assert!(
+            !merge_only || has_edge_from_text_to_text(&cfg, "fallthrough", "return x"),
+            "fallthrough should Jump into next case, not only Next-merge"
+        );
+    }
+
+    #[test]
+    fn test_go_goto_and_label() {
+        let code = r#"
+package demo
+
+func Jump(flag bool) int {
+    if flag {
+        goto Done
+    }
+    x := 1
+Done:
+    return x
+}
+"#;
+        let cfg = build_cfg_for_function("go", code, "Jump").unwrap();
+        assert!(
+            go_stmt_texts(&cfg).iter().any(|t| t.contains("goto Done")),
+            "goto must appear as Jump statement, got {:?}",
+            go_stmt_texts(&cfg)
+        );
+        let froms = block_ids_containing(&cfg, "goto Done");
+        let tos = block_ids_containing(&cfg, "return x");
+        let jump = cfg.edges.iter().any(|e| {
+            froms.contains(&e.from) && tos.contains(&e.to) && e.edge_type == CfgEdgeType::Jump
+        });
+        assert!(
+            jump,
+            "goto Done must Jump to the labeled return block, edges={:?}",
+            cfg.edges
+        );
+        assert!(
+            go_stmt_kinds(&cfg)
+                .iter()
+                .any(|k| *k == StatementKind::Return),
+            "labeled return must be lowered as Return, not opaque label blob"
+        );
+    }
+
+    #[test]
+    fn test_go_short_circuit_and_or() {
+        let code = r#"
+package demo
+
+func AndOr(a, b, c bool) int {
+    if a && b {
+        return 1
+    }
+    if a || c {
+        return 2
+    }
+    return 0
+}
+"#;
+        let cfg = build_cfg_for_function("go", code, "AndOr").unwrap();
+        let texts = go_stmt_texts(&cfg);
+        assert!(
+            texts.iter().any(|t| t == "a" || t.trim() == "a"),
+            "&& left operand should be its own branch, got {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t == "b" || t.trim() == "b"),
+            "&& right operand should be its own branch, got {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t == "c" || t.trim() == "c"),
+            "|| right operand should be its own branch, got {texts:?}"
+        );
+        assert!(
+            !texts.iter().any(|t| t.contains("a && b")),
+            "whole a && b must not remain a single Branch blob, got {texts:?}"
+        );
+        let if_true = cfg
+            .edges
+            .iter()
+            .filter(|e| e.edge_type == CfgEdgeType::IfTrue)
+            .count();
+        // a&&b and a||c each need multiple conditional edges
+        assert!(
+            if_true >= 4,
+            "short-circuit should create multiple IfTrue edges, got {if_true}"
+        );
+    }
+
+    fn can_reach(cfg: &ControlFlowGraph, from: uuid::Uuid, to: uuid::Uuid) -> bool {
+        use std::collections::{HashSet, VecDeque};
+        let mut seen = HashSet::new();
+        let mut q = VecDeque::from([from]);
+        while let Some(n) = q.pop_front() {
+            if n == to {
+                return true;
+            }
+            if !seen.insert(n) {
+                continue;
+            }
+            for e in &cfg.edges {
+                if e.from == n {
+                    q.push_back(e.to);
+                }
+            }
+        }
+        false
+    }
+
+    #[test]
+    fn test_go_labeled_break_and_continue() {
+        let code = r#"
+package demo
+
+func Nested() int {
+    n := 0
+Outer:
+    for i := 0; i < 3; i++ {
+        for j := 0; j < 3; j++ {
+            if j == 1 {
+                continue Outer
+            }
+            if j == 2 {
+                break Outer
+            }
+            n++
+        }
+    }
+    return n
+}
+"#;
+        let cfg = build_cfg_for_function("go", code, "Nested").unwrap();
+        let cont = block_ids_containing(&cfg, "continue Outer");
+        let brk = block_ids_containing(&cfg, "break Outer");
+        let updates = block_ids_containing(&cfg, "i++");
+        assert!(!cont.is_empty() && !brk.is_empty() && !updates.is_empty());
+
+        // continue Outer must reach outer update (i++), not only inner j++.
+        let reaches_outer_update = cont.iter().any(|c| {
+            updates.iter().any(|u| can_reach(&cfg, *c, *u))
+                && cfg.edges.iter().any(|e| {
+                    e.from == *c
+                        && e.edge_type == CfgEdgeType::Jump
+                        && updates.contains(&e.to)
+                })
+        });
+        assert!(
+            reaches_outer_update,
+            "continue Outer must Jump directly to outer i++ update"
+        );
+
+        // break Outer must not Jump to an inner-only exit that still runs outer update.
+        // It should Jump to a block from which i++ is NOT reached (loop exit).
+        let break_skips_update = brk.iter().any(|b| {
+            cfg.edges.iter().any(|e| {
+                e.from == *b
+                    && e.edge_type == CfgEdgeType::Jump
+                    && !updates.iter().any(|u| can_reach(&cfg, e.to, *u) && e.to != *u)
+                    && updates.iter().all(|u| e.to != *u)
+            })
+        });
+        assert!(
+            break_skips_update,
+            "break Outer must Jump to outer exit (not outer update)"
+        );
+    }
+
+    #[test]
+    fn test_go_defer_runs_before_return_exit() {
+        let code = r#"
+package demo
+
+func cleanup() {}
+
+func WithDefer() {
+    defer cleanup()
+    return
+}
+"#;
+        let cfg = build_cfg_for_function("go", code, "WithDefer").unwrap();
+        let texts = go_stmt_texts(&cfg);
+        assert!(
+            texts.iter().any(|t| t.contains("defer")),
+            "defer must be recorded, got {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t.contains("cleanup")),
+            "deferred call must appear on unwind path, got {texts:?}"
+        );
+        let rets = block_ids_containing(&cfg, "return");
+        let cleanups: Vec<_> = cfg
+            .blocks
+            .values()
+            .filter(|b| {
+                b.statements.iter().any(|s| {
+                    s.text.contains("cleanup") && !s.text.contains("defer")
+                })
+            })
+            .map(|b| b.id)
+            .collect();
+        assert!(!rets.is_empty() && !cleanups.is_empty());
+        // From return block, must reach a cleanup invocation before / on the way to a Return edge target.
+        let ok = rets.iter().any(|r| {
+            cleanups.iter().any(|c| can_reach(&cfg, *r, *c) || {
+                // cleanup block may be after return stmt via Next, then Return edge
+                cfg.edges.iter().any(|e| e.from == *r && e.to == *c)
+            })
+        });
+        assert!(ok, "return must route into deferred cleanup before exit");
+        assert!(
+            cfg.edges
+                .iter()
+                .any(|e| e.edge_type == CfgEdgeType::Return),
+            "must still have a Return edge to exit"
+        );
+    }
+
+    #[test]
+    fn test_go_defer_lifo_and_panic_unwind() {
+        let code = r#"
+package demo
+
+func a() {}
+func b() {}
+
+func PanicDefer() {
+    defer a()
+    defer b()
+    panic("boom")
+}
+"#;
+        let cfg = build_cfg_for_function("go", code, "PanicDefer").unwrap();
+        let texts = go_stmt_texts(&cfg);
+        assert!(
+            texts.iter().any(|t| t.contains("panic")),
+            "panic must appear, got {texts:?}"
+        );
+        // LIFO: b before a on unwind — find path panic -> b-call -> a-call
+        let panic_blocks = block_ids_containing(&cfg, "panic");
+        let b_blocks: Vec<_> = cfg
+            .blocks
+            .values()
+            .filter(|b| {
+                b.statements
+                    .iter()
+                    .any(|s| s.text.contains("b()") && !s.text.contains("defer"))
+            })
+            .map(|b| b.id)
+            .collect();
+        let a_blocks: Vec<_> = cfg
+            .blocks
+            .values()
+            .filter(|b| {
+                b.statements
+                    .iter()
+                    .any(|s| s.text.contains("a()") && !s.text.contains("defer"))
+            })
+            .map(|b| b.id)
+            .collect();
+        assert!(!panic_blocks.is_empty() && !b_blocks.is_empty() && !a_blocks.is_empty());
+        let lifo = panic_blocks.iter().any(|p| {
+            b_blocks.iter().any(|b| {
+                can_reach(&cfg, *p, *b)
+                    && a_blocks
+                        .iter()
+                        .any(|a| can_reach(&cfg, *b, *a))
+            })
+        });
+        assert!(
+            lifo,
+            "panic must unwind defers LIFO (b then a), texts={texts:?}"
+        );
     }
 
     #[test]

--- a/crates/rbuilder-analysis/src/cfg_builder.rs
+++ b/crates/rbuilder-analysis/src/cfg_builder.rs
@@ -330,6 +330,9 @@ impl<'a> CfgBuilder<'a> {
 
             // Declarations / assignments
             "let_declaration" | "let_statement" => {
+                if let Some(value) = node.child_by_field_name("value") {
+                    self.visit_expr_for_control_flow(value, source)?;
+                }
                 self.add_statement(node, source, StatementKind::Declaration)?;
                 Ok(())
             }
@@ -384,9 +387,21 @@ impl<'a> CfgBuilder<'a> {
                 Ok(())
             }
 
+            // Rust `expr?` and `.await`
+            "try_expression" => self.visit_try_expression(node, source),
+            "await_expression" => self.visit_await_expression(node, source),
+            "macro_invocation" => self.visit_macro_invocation(node, source),
+
             // Block / body wrapper
             k if is_block_like(k) => {
                 self.visit_block(node, source)?;
+                Ok(())
+            }
+            // Unwrap Rust `else { ... }` wrapper.
+            "else_clause" => {
+                if let Some(block) = find_child_kind(node, "block") {
+                    self.visit_block(block, source)?;
+                }
                 Ok(())
             }
 
@@ -405,18 +420,151 @@ impl<'a> CfgBuilder<'a> {
         match inner.kind() {
             "if_statement" | "if_expression" | "while_statement" | "while_expression"
             | "for_statement" | "for_expression" | "for_in_expression" | "loop_expression"
-            | "match_expression" | "return_statement" | "return_expression" => {
-                self.visit_statement(inner, source)
-            }
+            | "match_expression" | "return_statement" | "return_expression"
+            | "try_expression" | "await_expression" | "break_expression" | "continue_expression"
+            | "macro_invocation" => self.visit_statement(inner, source),
             _ => {
+                self.visit_expr_for_control_flow(inner, source)?;
+                if !self.flow_active {
+                    return Ok(());
+                }
                 let kind = Self::classify_expression(inner, source);
                 self.add_statement(inner, source, kind)?;
-                if is_panic_call(inner, source) {
+                if is_panic_call(inner, source) || is_diverging_macro(inner, source) {
                     self.unwind_defers_to_exit(CfgEdgeType::Exception);
                 }
                 Ok(())
             }
         }
+    }
+
+    /// Lower nested `?` / `.await` / control-flow expressions inside a larger expression.
+    fn visit_expr_for_control_flow(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        if !self.flow_active {
+            return Ok(());
+        }
+        match node.kind() {
+            "try_expression" => self.visit_try_expression(node, source),
+            "await_expression" => self.visit_await_expression(node, source),
+            "if_expression" | "if_statement" | "match_expression" | "loop_expression"
+            | "while_expression" | "while_statement" | "for_expression" | "for_statement"
+            | "return_expression" | "return_statement" | "break_expression"
+            | "continue_expression" | "macro_invocation" => self.visit_statement(node, source),
+            _ => {
+                let mut cursor = node.walk();
+                for child in node.children(&mut cursor) {
+                    if !child.is_named() {
+                        continue;
+                    }
+                    if matches!(
+                        child.kind(),
+                        "try_expression"
+                            | "await_expression"
+                            | "if_expression"
+                            | "match_expression"
+                            | "loop_expression"
+                            | "while_expression"
+                            | "for_expression"
+                            | "macro_invocation"
+                            | "return_expression"
+                            | "break_expression"
+                            | "continue_expression"
+                    ) {
+                        self.visit_expr_for_control_flow(child, source)?;
+                        if !self.flow_active {
+                            return Ok(());
+                        }
+                    } else {
+                        // Deep search for nested `?` / await (e.g. in call args).
+                        self.visit_expr_for_control_flow(child, source)?;
+                        if !self.flow_active {
+                            return Ok(());
+                        }
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn visit_try_expression(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        if let Some(inner) = node.named_child(0) {
+            self.visit_expr_for_control_flow(inner, source)?;
+            if !self.flow_active {
+                return Ok(());
+            }
+        }
+        let text = node
+            .utf8_text(source)
+            .unwrap_or("?")
+            .trim()
+            .to_string();
+        self.add_statement_to_current(Statement {
+            kind: StatementKind::Branch,
+            line: node.start_position().row + 1,
+            text,
+            defined_vars: HashSet::new(),
+            used_vars: HashSet::new(),
+        });
+        let ok_block = self.new_block();
+        let err_block = self.new_block();
+        let from = self.current_block;
+        self.cfg.add_edge(from, ok_block, CfgEdgeType::IfTrue);
+        self.cfg.add_edge(from, err_block, CfgEdgeType::IfFalse);
+        // Error path: early return from the function (`?`).
+        self.flow_active = true;
+        self.current_block = err_block;
+        self.unwind_finallies(source)?;
+        self.unwind_defers_to_exit(CfgEdgeType::Return);
+        // Success path continues.
+        self.flow_active = true;
+        self.current_block = ok_block;
+        Ok(())
+    }
+
+    fn visit_await_expression(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        if let Some(inner) = node.named_child(0) {
+            self.visit_expr_for_control_flow(inner, source)?;
+            if !self.flow_active {
+                return Ok(());
+            }
+        }
+        let text = node
+            .utf8_text(source)
+            .unwrap_or(".await")
+            .trim()
+            .to_string();
+        self.add_statement_to_current(Statement {
+            kind: StatementKind::Branch,
+            line: node.start_position().row + 1,
+            text,
+            defined_vars: HashSet::new(),
+            used_vars: HashSet::new(),
+        });
+        // Yield / resume split.
+        let resume = self.new_block();
+        self.cfg
+            .add_edge(self.current_block, resume, CfgEdgeType::Next);
+        self.current_block = resume;
+        Ok(())
+    }
+
+    fn visit_macro_invocation(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        let diverging = is_diverging_macro(node, source);
+        self.add_statement(
+            node,
+            source,
+            if diverging {
+                StatementKind::Jump
+            } else {
+                StatementKind::FunctionCall
+            },
+        )?;
+        if diverging {
+            self.unwind_finallies(source)?;
+            self.unwind_defers_to_exit(CfgEdgeType::Exception);
+        }
+        Ok(())
     }
 
     fn classify_expression(node: Node, _source: &[u8]) -> StatementKind {
@@ -488,11 +636,25 @@ impl<'a> CfgBuilder<'a> {
             .child_by_field_name("alternative")
             .or_else(|| node.child_by_field_name("else"))
         {
-            self.visit_block(alternative, source)?;
+            let alt = if alternative.kind() == "else_clause" {
+                find_child_kind(alternative, "block").unwrap_or(alternative)
+            } else if alternative.kind() == "if_expression" || alternative.kind() == "if_statement"
+            {
+                // `else if` — visit as nested if.
+                alternative
+            } else {
+                alternative
+            };
+            if alt.kind() == "if_expression" || alt.kind() == "if_statement" {
+                self.visit_if(alt, source)?;
+            } else {
+                self.visit_block(alt, source)?;
+            }
             false_end = self.current_block;
             false_reaches = self.flow_active;
         } else if let Some(else_clause) = node.child_by_field_name("else_clause") {
-            self.visit_block(else_clause, source)?;
+            let block = find_child_kind(else_clause, "block").unwrap_or(else_clause);
+            self.visit_block(block, source)?;
             false_end = self.current_block;
             false_reaches = self.flow_active;
         } else {
@@ -512,26 +674,27 @@ impl<'a> CfgBuilder<'a> {
     }
 
     fn visit_while(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        self.capture_embedded_loop_label(node, source);
         let header = self.new_block();
         self.cfg
             .add_edge(self.current_block, header, CfgEdgeType::Next);
-        self.add_statement_to_current(Statement {
-            kind: StatementKind::Branch,
-            line: node.start_position().row + 1,
-            text: node
-                .child_by_field_name("condition")
-                .and_then(|c| c.utf8_text(source).ok())
-                .unwrap_or("while")
-                .trim()
-                .to_string(),
-            defined_vars: HashSet::new(),
-            used_vars: HashSet::new(),
-        });
+        self.current_block = header;
 
         let body = self.new_block();
-        self.cfg.add_edge(header, body, CfgEdgeType::IfTrue);
         let exit = self.new_block();
-        self.cfg.add_edge(header, exit, CfgEdgeType::IfFalse);
+        if let Some(cond) = node.child_by_field_name("condition") {
+            self.wire_condition(cond, source, body, exit)?;
+        } else {
+            self.add_statement_to_current(Statement {
+                kind: StatementKind::Branch,
+                line: node.start_position().row + 1,
+                text: "while".to_string(),
+                defined_vars: HashSet::new(),
+                used_vars: HashSet::new(),
+            });
+            self.cfg.add_edge(header, body, CfgEdgeType::IfTrue);
+            self.cfg.add_edge(header, exit, CfgEdgeType::IfFalse);
+        }
 
         self.breakable_stack.push(BreakableContext {
             exit,
@@ -539,14 +702,18 @@ impl<'a> CfgBuilder<'a> {
             label: self.pending_breakable_label.take(),
         });
 
+        self.flow_active = true;
         self.current_block = body;
         if let Some(body_node) = node.child_by_field_name("body") {
             self.visit_block(body_node, source)?;
         }
-        self.cfg
-            .add_edge(self.current_block, header, CfgEdgeType::Jump);
+        if self.flow_active {
+            self.cfg
+                .add_edge(self.current_block, header, CfgEdgeType::Jump);
+        }
         self.breakable_stack.pop();
 
+        self.flow_active = true;
         self.current_block = exit;
         Ok(())
     }
@@ -593,6 +760,16 @@ impl<'a> CfgBuilder<'a> {
     }
 
     fn visit_for(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        self.capture_embedded_loop_label(node, source);
+
+        // Rust `for pat in iter` / similar for-in forms.
+        if node.child_by_field_name("value").is_some()
+            && node.child_by_field_name("pattern").is_some()
+            && node.kind() == "for_expression"
+        {
+            return self.visit_for_in(node, source);
+        }
+
         // Go: for_clause / range_clause. Java/C-like: fields init/condition/update.
         let mut for_clause = None;
         let mut range_clause = None;
@@ -742,6 +919,58 @@ impl<'a> CfgBuilder<'a> {
         Ok(())
     }
 
+    /// Rust / for-in: `for pat in iter { body }` — iter once, then next()/body cycle.
+    fn visit_for_in(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        if let Some(value) = node.child_by_field_name("value") {
+            self.add_statement(value, source, StatementKind::Expression)?;
+        }
+        let header = self.new_block();
+        self.cfg
+            .add_edge(self.current_block, header, CfgEdgeType::Next);
+        self.current_block = header;
+        let header_text = node
+            .child_by_field_name("pattern")
+            .and_then(|p| p.utf8_text(source).ok())
+            .map(|p| {
+                let iter = node
+                    .child_by_field_name("value")
+                    .and_then(|v| v.utf8_text(source).ok())
+                    .unwrap_or("iter")
+                    .trim();
+                format!("for {p} in {iter}")
+            })
+            .unwrap_or_else(|| "for-in".to_string());
+        self.add_statement_to_current(Statement {
+            kind: StatementKind::Branch,
+            line: node.start_position().row + 1,
+            text: header_text,
+            defined_vars: HashSet::new(),
+            used_vars: HashSet::new(),
+        });
+        let body = self.new_block();
+        let exit = self.new_block();
+        self.cfg.add_edge(header, body, CfgEdgeType::IfTrue);
+        self.cfg.add_edge(header, exit, CfgEdgeType::IfFalse);
+        self.breakable_stack.push(BreakableContext {
+            exit,
+            continue_target: Some(header),
+            label: self.pending_breakable_label.take(),
+        });
+        self.flow_active = true;
+        self.current_block = body;
+        if let Some(body_node) = node.child_by_field_name("body") {
+            self.visit_block(body_node, source)?;
+        }
+        if self.flow_active {
+            self.cfg
+                .add_edge(self.current_block, header, CfgEdgeType::Jump);
+        }
+        self.breakable_stack.pop();
+        self.flow_active = true;
+        self.current_block = exit;
+        Ok(())
+    }
+
     fn visit_enhanced_for(&mut self, node: Node, source: &[u8]) -> Result<()> {
         if let Some(value) = node.child_by_field_name("value") {
             self.add_statement(value, source, StatementKind::Expression)?;
@@ -787,28 +1016,31 @@ impl<'a> CfgBuilder<'a> {
     }
 
     fn visit_loop(&mut self, node: Node, source: &[u8]) -> Result<()> {
-        let header = self.new_block();
-        self.cfg
-            .add_edge(self.current_block, header, CfgEdgeType::Next);
+        self.capture_embedded_loop_label(node, source);
+        // Infinite loop: no IfFalse exit — only break/return/panic leave.
         let body = self.new_block();
-        self.cfg.add_edge(header, body, CfgEdgeType::IfTrue);
+        self.cfg
+            .add_edge(self.current_block, body, CfgEdgeType::Next);
         let exit = self.new_block();
-        self.cfg.add_edge(header, exit, CfgEdgeType::IfFalse);
 
         self.breakable_stack.push(BreakableContext {
             exit,
-            continue_target: Some(header),
+            continue_target: Some(body),
             label: self.pending_breakable_label.take(),
         });
 
+        self.flow_active = true;
         self.current_block = body;
         if let Some(body_node) = node.child_by_field_name("body") {
             self.visit_block(body_node, source)?;
         }
-        self.cfg
-            .add_edge(self.current_block, header, CfgEdgeType::Jump);
+        if self.flow_active {
+            self.cfg
+                .add_edge(self.current_block, body, CfgEdgeType::Jump);
+        }
         self.breakable_stack.pop();
 
+        self.flow_active = true;
         self.current_block = exit;
         Ok(())
     }
@@ -935,17 +1167,44 @@ impl<'a> CfgBuilder<'a> {
     fn jump_label_of(node: Node, source: &[u8]) -> Option<String> {
         let mut c = node.walk();
         for ch in node.children(&mut c) {
-            if ch.kind() == "label_name" {
-                return ch.utf8_text(source).ok().map(|s| s.trim().to_string());
+            if ch.kind() == "label_name" || ch.kind() == "label" {
+                return ch.utf8_text(source).ok().map(|s| {
+                    s.trim()
+                        .trim_start_matches('\'')
+                        .to_string()
+                });
             }
         }
-        // `break Outer` — second named child may be the label
+        // `break Outer` — named child may be the label
         if let Some(n) = node.named_child(0) {
-            if n.kind() == "label_name" || n.kind() == "identifier" {
-                return n.utf8_text(source).ok().map(|s| s.trim().to_string());
+            if n.kind() == "label_name" || n.kind() == "label" || n.kind() == "identifier" {
+                return n.utf8_text(source).ok().map(|s| {
+                    s.trim()
+                        .trim_start_matches('\'')
+                        .to_string()
+                });
             }
         }
         None
+    }
+
+    /// Rust embeds `'label:` on the loop node itself (not `labeled_statement`).
+    fn capture_embedded_loop_label(&mut self, node: Node, source: &[u8]) {
+        if self.pending_breakable_label.is_some() {
+            return;
+        }
+        let mut c = node.walk();
+        for ch in node.children(&mut c) {
+            if ch.kind() == "label" {
+                if let Ok(t) = ch.utf8_text(source) {
+                    let name = t.trim().trim_start_matches('\'').to_string();
+                    if !name.is_empty() {
+                        self.pending_breakable_label = Some(name);
+                    }
+                }
+                break;
+            }
+        }
     }
 
     fn find_breakable(&self, label: Option<&str>) -> Option<&BreakableContext> {
@@ -1190,14 +1449,34 @@ impl<'a> CfgBuilder<'a> {
     }
 
     fn visit_match(&mut self, node: Node, source: &[u8]) -> Result<()> {
-        self.add_statement(node, source, StatementKind::Branch)?;
+        let subject = node
+            .child_by_field_name("value")
+            .or_else(|| node.named_child(0))
+            .and_then(|n| n.utf8_text(source).ok())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "match".to_string());
+        self.add_statement_to_current(Statement {
+            kind: StatementKind::Branch,
+            line: node.start_position().row + 1,
+            text: subject,
+            defined_vars: HashSet::new(),
+            used_vars: HashSet::new(),
+        });
         let cond_block = self.current_block;
         let merge = self.new_block();
         let mut arms = Vec::new();
 
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
-            if child.kind() == "match_arm" || child.kind() == "match_arm_pattern" {
+            if child.kind() == "match_block" {
+                let mut bc = child.walk();
+                for arm in child.children(&mut bc) {
+                    if arm.kind() == "match_arm" {
+                        arms.push(arm);
+                    }
+                }
+            } else if child.kind() == "match_arm" || child.kind() == "match_arm_pattern" {
                 arms.push(child);
             }
         }
@@ -1208,21 +1487,62 @@ impl<'a> CfgBuilder<'a> {
             }
         }
 
+        let mut pending_fail: Option<BlockId> = None;
         for arm in arms {
-            let arm_block = self.new_block();
-            self.cfg
-                .add_edge(cond_block, arm_block, CfgEdgeType::IfTrue);
-            self.current_block = arm_block;
-            self.visit_block(arm, source)?;
-            self.cfg
-                .add_edge(self.current_block, merge, CfgEdgeType::Next);
+            let test = self.new_block();
+            if let Some(fail) = pending_fail.take() {
+                self.cfg.add_edge(fail, test, CfgEdgeType::Next);
+            } else {
+                self.cfg
+                    .add_edge(cond_block, test, CfgEdgeType::IfTrue);
+            }
+            self.flow_active = true;
+            self.current_block = test;
+
+            let body = self.new_block();
+            let fail = self.new_block();
+            let guard = arm
+                .child_by_field_name("pattern")
+                .and_then(|p| p.child_by_field_name("condition"));
+            if let Some(guard) = guard {
+                // Pattern assumed matched; guard decides body vs next arm.
+                self.wire_condition(guard, source, body, fail)?;
+            } else {
+                let pat_text = arm
+                    .child_by_field_name("pattern")
+                    .and_then(|p| p.utf8_text(source).ok())
+                    .map(|s| s.trim().to_string())
+                    .unwrap_or_else(|| "arm".to_string());
+                self.add_statement_to_current(Statement {
+                    kind: StatementKind::Branch,
+                    line: arm.start_position().row + 1,
+                    text: pat_text,
+                    defined_vars: HashSet::new(),
+                    used_vars: HashSet::new(),
+                });
+                self.cfg.add_edge(test, body, CfgEdgeType::IfTrue);
+                self.cfg.add_edge(test, fail, CfgEdgeType::IfFalse);
+            }
+            pending_fail = Some(fail);
+
+            self.flow_active = true;
+            self.current_block = body;
+            if let Some(value) = arm.child_by_field_name("value") {
+                self.visit_statement(value, source)?;
+            } else {
+                self.visit_block(arm, source)?;
+            }
+            if self.flow_active {
+                self.cfg
+                    .add_edge(self.current_block, merge, CfgEdgeType::Next);
+            }
         }
 
-        let default_block = self.new_block();
-        self.cfg
-            .add_edge(cond_block, default_block, CfgEdgeType::IfFalse);
-        self.cfg.add_edge(default_block, merge, CfgEdgeType::Next);
+        if let Some(fail) = pending_fail {
+            self.cfg.add_edge(fail, merge, CfgEdgeType::Next);
+        }
 
+        self.flow_active = true;
         self.current_block = merge;
         Ok(())
     }
@@ -1696,6 +2016,22 @@ fn is_panic_call(node: Node, source: &[u8]) -> bool {
         .is_some_and(|s| s.trim() == "panic")
 }
 
+fn is_diverging_macro(node: Node, source: &[u8]) -> bool {
+    if node.kind() != "macro_invocation" {
+        return false;
+    }
+    let name = node
+        .child_by_field_name("macro")
+        .or_else(|| node.named_child(0))
+        .and_then(|n| n.utf8_text(source).ok())
+        .unwrap_or("")
+        .trim();
+    matches!(
+        name,
+        "panic" | "todo" | "unimplemented" | "unreachable"
+    )
+}
+
 fn logical_operator<'a>(node: Node<'a>, source: &'a [u8]) -> Option<&'a str> {
     if node.kind() != "binary_expression" {
         return None;
@@ -1748,6 +2084,339 @@ fn loop_example(n: i32) -> i32 {
 "#;
         let cfg = build_cfg_for_function("rust", code, "loop_example").unwrap();
         assert!(cfg.has_cycle());
+    }
+
+    fn rust_texts(cfg: &ControlFlowGraph) -> Vec<String> {
+        cfg.blocks
+            .values()
+            .flat_map(|b| b.statements.iter().map(|s| s.text.clone()))
+            .collect()
+    }
+
+    fn rust_kinds(cfg: &ControlFlowGraph) -> Vec<StatementKind> {
+        cfg.blocks
+            .values()
+            .flat_map(|b| b.statements.iter().map(|s| s.kind))
+            .collect()
+    }
+
+    fn rust_block_ids(cfg: &ControlFlowGraph, needle: &str) -> Vec<uuid::Uuid> {
+        cfg.blocks
+            .values()
+            .filter(|b| b.statements.iter().any(|s| s.text.contains(needle)))
+            .map(|b| b.id)
+            .collect()
+    }
+
+    #[test]
+    fn test_rust_short_circuit_and() {
+        let code = r#"
+fn sc(a: bool, b: bool) -> i32 {
+    if a && b {
+        return 1;
+    }
+    0
+}
+"#;
+        let cfg = build_cfg_for_function("rust", code, "sc").unwrap();
+        let texts = rust_texts(&cfg);
+        assert!(
+            texts.iter().any(|t| t.trim() == "a"),
+            "&& left must be its own branch, got {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t.trim() == "b"),
+            "&& right must be its own branch, got {texts:?}"
+        );
+        assert!(
+            !texts.iter().any(|t| t.contains("a && b")),
+            "must not keep a && b as one blob, got {texts:?}"
+        );
+    }
+
+    #[test]
+    fn test_rust_if_let_branches() {
+        let code = r#"
+fn il(opt: Option<i32>) -> i32 {
+    if let Some(x) = opt {
+        return x;
+    }
+    0
+}
+"#;
+        let cfg = build_cfg_for_function("rust", code, "il").unwrap();
+        assert!(
+            cfg.edges
+                .iter()
+                .any(|e| e.edge_type == CfgEdgeType::IfTrue)
+                && cfg
+                    .edges
+                    .iter()
+                    .any(|e| e.edge_type == CfgEdgeType::IfFalse),
+            "if let must split true/false"
+        );
+        assert!(
+            rust_kinds(&cfg)
+                .iter()
+                .any(|k| *k == StatementKind::Return),
+            "if-let body return must lower"
+        );
+        assert!(
+            !rust_texts(&cfg)
+                .iter()
+                .any(|t| t.trim_start().starts_with("if let Some")),
+            "if let must not stay opaque, got {:?}",
+            rust_texts(&cfg)
+        );
+    }
+
+    #[test]
+    fn test_rust_match_arms_and_guards() {
+        let code = r#"
+fn m(opt: Option<i32>) -> i32 {
+    match opt {
+        Some(v) if v > 0 => return v,
+        Some(v) => return v + 1,
+        None => return 0,
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("rust", code, "m").unwrap();
+        let returns = rust_kinds(&cfg)
+            .iter()
+            .filter(|k| **k == StatementKind::Return)
+            .count();
+        assert!(returns >= 3, "each arm return must lower, kinds={:?}", rust_kinds(&cfg));
+        assert!(
+            !rust_texts(&cfg)
+                .iter()
+                .any(|t| t.contains("Some(v) if v > 0 =>") && t.contains("None")),
+            "match must not stay one blob, got {:?}",
+            rust_texts(&cfg)
+        );
+        // Guard condition should appear as its own branch text.
+        assert!(
+            rust_texts(&cfg)
+                .iter()
+                .any(|t| t.contains("v > 0") || t.trim() == "v > 0"),
+            "match guard must lower, got {:?}",
+            rust_texts(&cfg)
+        );
+        let ret_edges = cfg
+            .edges
+            .iter()
+            .filter(|e| e.edge_type == CfgEdgeType::Return)
+            .count();
+        assert!(ret_edges >= 3, "Return edges from arms, got {ret_edges}");
+    }
+
+    #[test]
+    fn test_rust_try_operator_early_return() {
+        let code = r#"
+fn t() -> Result<i32, ()> {
+    let y = foo()?;
+    Ok(y)
+}
+fn foo() -> Result<i32, ()> { Ok(1) }
+"#;
+        let cfg = build_cfg_for_function("rust", code, "t").unwrap();
+        let texts = rust_texts(&cfg);
+        assert!(
+            texts.iter().any(|t| t.contains("foo()?") || t.contains("?")),
+            "? must appear as branch, got {texts:?}"
+        );
+        assert!(
+            cfg.edges.iter().any(|e| {
+                matches!(
+                    e.edge_type,
+                    CfgEdgeType::Return | CfgEdgeType::Exception | CfgEdgeType::IfFalse
+                )
+            }),
+            "? error path must early-exit"
+        );
+        // Success path should still reach Ok(y) / trailing result.
+        assert!(
+            texts.iter().any(|t| t.contains("Ok(y)") || t.contains("let y")),
+            "success path must continue after ?, got {texts:?}"
+        );
+    }
+
+    #[test]
+    fn test_rust_infinite_loop_no_false_exit() {
+        let code = r#"
+fn forever() -> i32 {
+    loop {
+        break 1;
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("rust", code, "forever").unwrap();
+        assert!(cfg.has_cycle() || rust_texts(&cfg).iter().any(|t| t.contains("break")));
+        // Header must not offer a false edge out of an infinite loop.
+        let break_blocks = rust_block_ids(&cfg, "break");
+        assert!(!break_blocks.is_empty(), "break must lower");
+        assert!(
+            cfg.edges
+                .iter()
+                .any(|e| break_blocks.contains(&e.from) && e.edge_type == CfgEdgeType::Jump),
+            "break must Jump to loop exit"
+        );
+    }
+
+    #[test]
+    fn test_rust_for_in_value_and_cycle() {
+        let code = r#"
+fn sum(n: i32) -> i32 {
+    let mut t = 0;
+    for i in 0..n {
+        t += i;
+    }
+    t
+}
+"#;
+        let cfg = build_cfg_for_function("rust", code, "sum").unwrap();
+        assert!(cfg.has_cycle());
+        let texts = rust_texts(&cfg);
+        assert!(
+            texts.iter().any(|t| t.contains("0..n") || t.contains("for")),
+            "iterator value must appear, got {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t.contains("t += i") || t.contains("t+=i")),
+            "body must lower, got {texts:?}"
+        );
+    }
+
+    #[test]
+    fn test_rust_labeled_break_continue() {
+        let code = r#"
+fn nested(n: i32) -> i32 {
+    let mut s = 0;
+    'outer: for i in 0..n {
+        loop {
+            if i == 0 {
+                continue 'outer;
+            }
+            if i < 0 {
+                break 'outer;
+            }
+            s += 1;
+            break;
+        }
+    }
+    s
+}
+"#;
+        let cfg = build_cfg_for_function("rust", code, "nested").unwrap();
+        let cont = rust_block_ids(&cfg, "continue 'outer");
+        let brk = rust_block_ids(&cfg, "break 'outer");
+        assert!(!cont.is_empty() && !brk.is_empty(), "labeled jumps must lower");
+        // continue 'outer should Jump to outer for header (not inner loop).
+        assert!(
+            cont.iter().any(|c| {
+                cfg.edges
+                    .iter()
+                    .any(|e| e.from == *c && e.edge_type == CfgEdgeType::Jump)
+            }),
+            "continue 'outer must Jump"
+        );
+        assert!(
+            brk.iter().any(|b| {
+                cfg.edges
+                    .iter()
+                    .any(|e| e.from == *b && e.edge_type == CfgEdgeType::Jump)
+            }),
+            "break 'outer must Jump"
+        );
+        // Different targets: continue → header cycle path, break → exit (no shared sole target required,
+        // but they must not both only target the same empty set).
+        let cont_tgts: Vec<_> = cfg
+            .edges
+            .iter()
+            .filter(|e| cont.contains(&e.from) && e.edge_type == CfgEdgeType::Jump)
+            .map(|e| e.to)
+            .collect();
+        let brk_tgts: Vec<_> = cfg
+            .edges
+            .iter()
+            .filter(|e| brk.contains(&e.from) && e.edge_type == CfgEdgeType::Jump)
+            .map(|e| e.to)
+            .collect();
+        assert!(
+            cont_tgts.iter().any(|t| !brk_tgts.contains(t))
+                || brk_tgts.iter().any(|t| !cont_tgts.contains(t)),
+            "continue and break 'outer must target different blocks"
+        );
+    }
+
+    #[test]
+    fn test_rust_panic_macro_exits() {
+        let code = r#"
+fn boom() {
+    panic!("x");
+}
+"#;
+        let cfg = build_cfg_for_function("rust", code, "boom").unwrap();
+        assert!(
+            rust_texts(&cfg)
+                .iter()
+                .any(|t| t.contains("panic")),
+            "panic! must appear, got {:?}",
+            rust_texts(&cfg)
+        );
+        assert!(
+            cfg.edges.iter().any(|e| {
+                matches!(
+                    e.edge_type,
+                    CfgEdgeType::Exception | CfgEdgeType::Return | CfgEdgeType::Jump
+                )
+            }),
+            "panic! must terminate"
+        );
+    }
+
+    #[test]
+    fn test_rust_await_splits_block() {
+        let code = r#"
+async fn aw() -> i32 {
+    let x = async { 1 }.await;
+    x
+}
+"#;
+        let cfg = build_cfg_for_function("rust", code, "aw").unwrap();
+        assert!(
+            rust_texts(&cfg)
+                .iter()
+                .any(|t| t.contains("await")),
+            "await must appear, got {:?}",
+            rust_texts(&cfg)
+        );
+        assert!(
+            cfg.blocks.len() >= 3,
+            "await should split basic blocks, blocks={}",
+            cfg.blocks.len()
+        );
+    }
+
+    #[test]
+    fn test_rust_while_let_cycle() {
+        let code = r#"
+fn wl() -> i32 {
+    let mut t = 0;
+    while let Some(x) = None::<i32> {
+        t += x;
+    }
+    t
+}
+"#;
+        let cfg = build_cfg_for_function("rust", code, "wl").unwrap();
+        assert!(cfg.has_cycle(), "while let must cycle");
+        assert!(
+            rust_texts(&cfg)
+                .iter()
+                .any(|t| t.contains("t += x") || t.contains("t+=x")),
+            "while-let body must lower"
+        );
     }
 
     #[test]

--- a/crates/rbuilder-analysis/src/cfg_builder.rs
+++ b/crates/rbuilder-analysis/src/cfg_builder.rs
@@ -168,6 +168,10 @@ struct CfgBuilder<'a> {
     switch_implicit_fallthrough: bool,
     /// C `setjmp` sites in this function (approx targets for `longjmp`).
     setjmp_sites: Vec<BlockId>,
+    /// Innermost-first C# `switch` case labels for `goto case` / `goto default`.
+    switch_case_labels: Vec<HashMap<String, BlockId>>,
+    /// Exit blocks for nested local-function / lambda sub-CFGs (not function exits).
+    nested_exits: Vec<BlockId>,
 }
 
 struct BreakableContext {
@@ -202,6 +206,8 @@ impl<'a> CfgBuilder<'a> {
             try_catch_stack: Vec::new(),
             switch_implicit_fallthrough: false,
             setjmp_sites: Vec::new(),
+            switch_case_labels: Vec::new(),
+            nested_exits: Vec::new(),
         }
     }
 
@@ -290,16 +296,27 @@ impl<'a> CfgBuilder<'a> {
     }
 
     fn visit_block(&mut self, node: Node, source: &[u8]) -> Result<BlockId> {
+        let mut using_decls = 0usize;
         if is_block_like(node.kind()) {
             let mut cursor = node.walk();
             for child in node.children(&mut cursor) {
-                if child.is_named() {
+                if !child.is_named() {
+                    continue;
+                }
+                if is_csharp_using_declaration(child, source) {
+                    self.visit_using_declaration(child, source)?;
+                    using_decls += 1;
+                } else {
                     self.visit_statement(child, source)?;
                 }
             }
+        } else if is_csharp_using_declaration(node, source) {
+            self.visit_using_declaration(node, source)?;
+            using_decls += 1;
         } else {
             self.visit_statement(node, source)?;
         }
+        self.close_using_declarations(using_decls)?;
         Ok(self.current_block)
     }
 
@@ -317,15 +334,30 @@ impl<'a> CfgBuilder<'a> {
             "enhanced_for_statement" => self.visit_enhanced_for(node, source),
             "loop_expression" => self.visit_loop(node, source),
 
-            // Returns / coroutine returns
+            // Returns / coroutine / iterator yields
             "return_statement" | "return_expression" | "co_return_statement" => {
                 self.visit_return(node, source)
             }
-            "yield_statement" | "co_yield_statement" | "co_yield_expression" => {
-                self.visit_co_yield(node, source)
-            }
+            "co_yield_statement" | "co_yield_expression" => self.visit_co_yield(node, source),
+            "yield_statement" => self.visit_yield_statement(node, source),
             "throw_statement" | "throw_expression" => self.visit_throw(node, source),
             "co_await_expression" => self.visit_co_await(node, source),
+            "await_expression" => self.visit_await_expression(node, source),
+
+            // C# local functions / lambdas → disconnected sub-CFGs
+            "local_function_statement" => self.visit_nested_subcfg(node, source),
+            "lambda_expression" | "anonymous_method_expression" => {
+                self.visit_nested_subcfg(node, source)
+            }
+
+            // C# resource / sync sugar → finally-style cleanup
+            "using_statement" => self.visit_using_statement(node, source),
+            "lock_statement" => self.visit_lock_statement(node, source),
+
+            // Null-conditional / coalescing (also visited from expr walk)
+            "conditional_access_expression" => {
+                self.visit_conditional_access(node, source)
+            }
 
             // Jumps
             "break_expression" | "break_statement" => self.visit_break(node, source),
@@ -352,6 +384,9 @@ impl<'a> CfgBuilder<'a> {
             | "local_variable_declaration"
             | "declaration"
             | "init_statement" => {
+                if is_csharp_using_declaration(node, source) {
+                    return self.visit_using_declaration(node, source);
+                }
                 if node.kind() == "init_statement" {
                     let mut c = node.walk();
                     for child in node.children(&mut c) {
@@ -373,7 +408,8 @@ impl<'a> CfgBuilder<'a> {
                 self.add_statement(node, source, StatementKind::Assignment)?;
                 Ok(())
             }
-            "inc_statement" | "dec_statement" | "send_statement" | "update_expression" => {
+            "inc_statement" | "dec_statement" | "send_statement" | "update_expression"
+            | "postfix_unary_expression" | "prefix_unary_expression" => {
                 self.add_statement(node, source, StatementKind::Expression)?;
                 Ok(())
             }
@@ -387,11 +423,11 @@ impl<'a> CfgBuilder<'a> {
             // Rust match
             "match_expression" => self.visit_match(node, source),
 
-            // Switch (Go + Java `switch_expression`)
+            // Switch (Go + Java/C# `switch_expression`)
             "switch_statement"
             | "type_switch_statement"
-            | "expression_switch_statement"
-            | "switch_expression" => self.visit_switch(node, source),
+            | "expression_switch_statement" => self.visit_switch(node, source),
+            "switch_expression" => self.visit_switch_expression(node, source),
             "select_statement" => self.visit_select(node, source),
 
             // Go concurrency helpers
@@ -408,9 +444,8 @@ impl<'a> CfgBuilder<'a> {
                 Ok(())
             }
 
-            // Rust `expr?` and `.await`
+            // Rust `expr?` (await already matched above)
             "try_expression" => self.visit_try_expression(node, source),
-            "await_expression" => self.visit_await_expression(node, source),
             "macro_invocation" => self.visit_macro_invocation(node, source),
 
             // Block / body wrapper
@@ -442,10 +477,16 @@ impl<'a> CfgBuilder<'a> {
             "if_statement" | "if_expression" | "while_statement" | "while_expression"
             | "for_statement" | "for_expression" | "for_in_expression" | "loop_expression"
             | "match_expression" | "return_statement" | "return_expression"
-            |             "try_expression" | "await_expression" | "break_expression" | "continue_expression"
+            | "try_expression" | "await_expression" | "break_expression" | "continue_expression"
             | "macro_invocation" | "conditional_expression" | "co_await_expression"
             | "throw_statement" | "throw_expression" | "co_yield_statement"
-            | "co_return_statement" => self.visit_statement(inner, source),
+            | "co_return_statement" | "switch_expression"
+            | "conditional_access_expression"
+            | "lambda_expression"
+            | "anonymous_method_expression" => self.visit_statement(inner, source),
+            "binary_expression" if null_coalesce_operator(inner, source) => {
+                self.visit_null_coalesce(inner, source)
+            }
             _ => {
                 self.visit_expr_for_control_flow(inner, source)?;
                 if !self.flow_active {
@@ -476,6 +517,14 @@ impl<'a> CfgBuilder<'a> {
         match node.kind() {
             "try_expression" => self.visit_try_expression(node, source),
             "await_expression" => self.visit_await_expression(node, source),
+            "conditional_access_expression" => self.visit_conditional_access(node, source),
+            "switch_expression" => self.visit_switch_expression(node, source),
+            "lambda_expression" | "anonymous_method_expression" => {
+                self.visit_nested_subcfg(node, source)
+            }
+            "binary_expression" if null_coalesce_operator(node, source) => {
+                self.visit_null_coalesce(node, source)
+            }
             "if_expression" | "if_statement" | "match_expression" | "loop_expression"
             | "while_expression" | "while_statement" | "for_expression" | "for_statement"
             | "return_expression" | "return_statement" | "break_expression"
@@ -651,10 +700,26 @@ impl<'a> CfgBuilder<'a> {
             defined_vars: HashSet::new(),
             used_vars: HashSet::new(),
         });
-        // Yield / resume split.
+        let from = self.current_block;
         let resume = self.new_block();
-        self.cfg
-            .add_edge(self.current_block, resume, CfgEdgeType::Next);
+        // Async state machine: completed → resume; incomplete → suspend/yield to caller.
+        if matches!(
+            self.language.to_lowercase().as_str(),
+            "csharp" | "cs" | "c#"
+        ) {
+            self.cfg.add_edge(from, resume, CfgEdgeType::IfTrue);
+            let suspend = self.new_block();
+            self.cfg.add_edge(from, suspend, CfgEdgeType::IfFalse);
+            if let Some(&nested) = self.nested_exits.last() {
+                self.cfg
+                    .add_edge(suspend, nested, CfgEdgeType::Return);
+            } else {
+                self.cfg.exits.push(suspend);
+            }
+        } else {
+            self.cfg.add_edge(from, resume, CfgEdgeType::Next);
+        }
+        self.flow_active = true;
         self.current_block = resume;
         Ok(())
     }
@@ -691,6 +756,201 @@ impl<'a> CfgBuilder<'a> {
         self.cfg
             .add_edge(self.current_block, resume, CfgEdgeType::Next);
         self.current_block = resume;
+        Ok(())
+    }
+
+    /// C# `yield return` (suspend) / `yield break` (exit).
+    fn visit_yield_statement(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        let text = node.utf8_text(source).unwrap_or("yield").trim().to_string();
+        if text.contains("break") {
+            self.add_statement(node, source, StatementKind::Jump)?;
+            self.unwind_finallies(source)?;
+            self.unwind_defers_to_exit(CfgEdgeType::Return);
+            return Ok(());
+        }
+        self.add_statement(node, source, StatementKind::Branch)?;
+        let resume = self.new_block();
+        self.cfg
+            .add_edge(self.current_block, resume, CfgEdgeType::Next);
+        self.current_block = resume;
+        Ok(())
+    }
+
+    /// C# `using (var r = ...) { }` → finally-style `r.Dispose()`.
+    fn visit_using_statement(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        let mut resource_name = "resource".to_string();
+        let mut resource_line = node.start_position().row + 1;
+        let mut c = node.walk();
+        for child in node.children(&mut c) {
+            if child.kind() == "variable_declaration" || child.kind() == "declaration" {
+                self.add_statement(child, source, StatementKind::Declaration)?;
+                resource_line = child.start_position().row + 1;
+                // Best-effort: first identifier in the declaration.
+                if let Some(id) = find_child_kind(child, "identifier") {
+                    if let Ok(t) = id.utf8_text(source) {
+                        resource_name = t.trim().to_string();
+                    }
+                }
+            }
+        }
+        let dispose = vec![DeferredCall {
+            text: format!("{resource_name}.Dispose()"),
+            line: resource_line,
+        }];
+        self.finally_stack.push(dispose.clone());
+
+        if let Some(body) = node.child_by_field_name("body") {
+            self.visit_block(body, source)?;
+        } else if let Some(block) = find_child_kind(node, "block") {
+            self.visit_block(block, source)?;
+        }
+
+        if self.flow_active {
+            for d in &dispose {
+                let b = self.new_block();
+                self.cfg
+                    .add_edge(self.current_block, b, CfgEdgeType::Next);
+                self.current_block = b;
+                self.add_statement_to_current(Statement {
+                    kind: StatementKind::Expression,
+                    line: d.line,
+                    text: d.text.clone(),
+                    defined_vars: HashSet::new(),
+                    used_vars: HashSet::new(),
+                });
+            }
+        }
+        self.finally_stack.pop();
+        Ok(())
+    }
+
+    /// C# `lock (obj) { }` → finally-style `Monitor.Exit(obj)`.
+    fn visit_lock_statement(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        let mut obj = "obj".to_string();
+        let line = node.start_position().row + 1;
+        if let Some(id) = node.named_child(0) {
+            if let Ok(t) = id.utf8_text(source) {
+                obj = t.trim().to_string();
+            }
+        }
+        let exit_call = vec![DeferredCall {
+            text: format!("Monitor.Exit({obj})"),
+            line,
+        }];
+        self.finally_stack.push(exit_call.clone());
+
+        if let Some(body) = node.child_by_field_name("body") {
+            self.visit_block(body, source)?;
+        } else if let Some(block) = find_child_kind(node, "block") {
+            self.visit_block(block, source)?;
+        }
+
+        if self.flow_active {
+            for d in &exit_call {
+                let b = self.new_block();
+                self.cfg
+                    .add_edge(self.current_block, b, CfgEdgeType::Next);
+                self.current_block = b;
+                self.add_statement_to_current(Statement {
+                    kind: StatementKind::Expression,
+                    line: d.line,
+                    text: d.text.clone(),
+                    defined_vars: HashSet::new(),
+                    used_vars: HashSet::new(),
+                });
+            }
+        }
+        self.finally_stack.pop();
+        Ok(())
+    }
+
+    /// C# `obj?.Member` — null short-circuit.
+    fn visit_conditional_access(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        let obj = node
+            .child_by_field_name("condition")
+            .or_else(|| node.named_child(0))
+            .unwrap_or(node);
+        let text = obj.utf8_text(source).unwrap_or("obj").trim().to_string();
+        self.add_statement_to_current(Statement {
+            kind: StatementKind::Branch,
+            line: node.start_position().row + 1,
+            text: format!("{text}?."),
+            defined_vars: HashSet::new(),
+            used_vars: HashSet::new(),
+        });
+        let non_null = self.new_block();
+        let null_path = self.new_block();
+        let merge = self.new_block();
+        let from = self.current_block;
+        self.cfg.add_edge(from, non_null, CfgEdgeType::IfTrue);
+        self.cfg.add_edge(from, null_path, CfgEdgeType::IfFalse);
+        // Non-null: continue access (opaque remainder).
+        self.flow_active = true;
+        self.current_block = non_null;
+        self.add_statement(node, source, StatementKind::Expression)?;
+        if self.flow_active {
+            self.cfg
+                .add_edge(self.current_block, merge, CfgEdgeType::Next);
+        }
+        self.flow_active = true;
+        self.current_block = null_path;
+        self.cfg
+            .add_edge(self.current_block, merge, CfgEdgeType::Next);
+        self.flow_active = true;
+        self.current_block = merge;
+        Ok(())
+    }
+
+    /// C# `a ?? b` — evaluate `b` only if `a` is null.
+    fn visit_null_coalesce(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        let left = node
+            .child_by_field_name("left")
+            .ok_or_else(|| Error::ParseError {
+                file: "source".into(),
+                line: node.start_position().row + 1,
+                message: "?? missing left".into(),
+            })?;
+        let right = node
+            .child_by_field_name("right")
+            .ok_or_else(|| Error::ParseError {
+                file: "source".into(),
+                line: node.start_position().row + 1,
+                message: "?? missing right".into(),
+            })?;
+        self.visit_expr_for_control_flow(left, source)?;
+        if !self.flow_active {
+            return Ok(());
+        }
+        let left_text = left.utf8_text(source).unwrap_or("left").trim().to_string();
+        self.add_statement_to_current(Statement {
+            kind: StatementKind::Branch,
+            line: node.start_position().row + 1,
+            text: format!("{left_text} ??"),
+            defined_vars: HashSet::new(),
+            used_vars: HashSet::new(),
+        });
+        let non_null = self.new_block();
+        let null_path = self.new_block();
+        let merge = self.new_block();
+        let from = self.current_block;
+        self.cfg.add_edge(from, non_null, CfgEdgeType::IfTrue);
+        self.cfg.add_edge(from, null_path, CfgEdgeType::IfFalse);
+        self.flow_active = true;
+        self.current_block = non_null;
+        self.cfg
+            .add_edge(self.current_block, merge, CfgEdgeType::Next);
+        self.flow_active = true;
+        self.current_block = null_path;
+        self.visit_expr_for_control_flow(right, source)?;
+        if self.flow_active {
+            self.add_statement(right, source, StatementKind::Expression)?;
+            if self.flow_active {
+                self.cfg
+                    .add_edge(self.current_block, merge, CfgEdgeType::Next);
+            }
+        }
+        self.flow_active = true;
+        self.current_block = merge;
         Ok(())
     }
 
@@ -920,7 +1180,10 @@ impl<'a> CfgBuilder<'a> {
     fn visit_for(&mut self, node: Node, source: &[u8]) -> Result<()> {
         self.capture_embedded_loop_label(node, source);
 
-        // C++ range-for: `for (T v : range)`
+        // C# foreach / C++ range-for
+        if node.kind() == "foreach_statement" {
+            return self.visit_foreach(node, source);
+        }
         if node.kind() == "for_range_loop" {
             return self.visit_for_range(node, source);
         }
@@ -1076,6 +1339,60 @@ impl<'a> CfgBuilder<'a> {
             }
         }
 
+        self.breakable_stack.pop();
+        self.flow_active = true;
+        self.current_block = exit;
+        Ok(())
+    }
+
+    /// C# `foreach (var v in xs)`
+    fn visit_foreach(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        if let Some(right) = node.child_by_field_name("right") {
+            self.add_statement(right, source, StatementKind::Expression)?;
+        }
+        let header = self.new_block();
+        self.cfg
+            .add_edge(self.current_block, header, CfgEdgeType::Next);
+        self.current_block = header;
+        let header_text = {
+            let left = node
+                .child_by_field_name("left")
+                .and_then(|l| l.utf8_text(source).ok())
+                .unwrap_or("v")
+                .trim();
+            let right = node
+                .child_by_field_name("right")
+                .and_then(|r| r.utf8_text(source).ok())
+                .unwrap_or("xs")
+                .trim();
+            // Avoid opaque `foreach ...` blobs; tests treat those as unlowered.
+            format!("for-each {left} in {right}")
+        };
+        self.add_statement_to_current(Statement {
+            kind: StatementKind::Branch,
+            line: node.start_position().row + 1,
+            text: header_text,
+            defined_vars: HashSet::new(),
+            used_vars: HashSet::new(),
+        });
+        let body = self.new_block();
+        let exit = self.new_block();
+        self.cfg.add_edge(header, body, CfgEdgeType::IfTrue);
+        self.cfg.add_edge(header, exit, CfgEdgeType::IfFalse);
+        self.breakable_stack.push(BreakableContext {
+            exit,
+            continue_target: Some(header),
+            label: self.pending_breakable_label.take(),
+        });
+        self.flow_active = true;
+        self.current_block = body;
+        if let Some(body_node) = node.child_by_field_name("body") {
+            self.visit_block(body_node, source)?;
+        }
+        if self.flow_active {
+            self.cfg
+                .add_edge(self.current_block, header, CfgEdgeType::Jump);
+        }
         self.breakable_stack.pop();
         self.flow_active = true;
         self.current_block = exit;
@@ -1274,7 +1591,7 @@ impl<'a> CfgBuilder<'a> {
             }
             found
         } {
-            self.visit_switch(sw, source)?;
+            self.visit_switch_expression(sw, source)?;
             if !self.flow_active {
                 return Ok(());
             }
@@ -1316,6 +1633,26 @@ impl<'a> CfgBuilder<'a> {
             self.unwind_finallies(source)?;
             self.unwind_defers_to_exit(CfgEdgeType::Return);
             return Ok(());
+        }
+
+        // C#: `return a ?? b;` / `return d?.M();` / nested await — lower CF first.
+        {
+            let mut c = node.walk();
+            for ch in node.children(&mut c) {
+                if !ch.is_named() {
+                    continue;
+                }
+                if matches!(
+                    ch.kind(),
+                    "switch_expression" | "conditional_expression"
+                ) {
+                    continue;
+                }
+                self.visit_expr_for_control_flow(ch, source)?;
+                if !self.flow_active {
+                    return Ok(());
+                }
+            }
         }
 
         self.add_statement(node, source, StatementKind::Return)?;
@@ -1385,6 +1722,181 @@ impl<'a> CfgBuilder<'a> {
         Ok(())
     }
 
+    /// C# `using var r = ...;` — Dispose at end of enclosing block / on return.
+    fn visit_using_declaration(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        self.add_statement(node, source, StatementKind::Declaration)?;
+        let mut resource_name = "resource".to_string();
+        let line = node.start_position().row + 1;
+        if let Some(decl) = find_child_kind(node, "variable_declaration")
+            .or_else(|| find_child_kind(node, "variable_declarator"))
+        {
+            if let Some(id) = find_child_kind(decl, "identifier") {
+                if let Ok(t) = id.utf8_text(source) {
+                    resource_name = t.trim().to_string();
+                }
+            }
+        } else if let Some(id) = find_child_kind(node, "identifier") {
+            if let Ok(t) = id.utf8_text(source) {
+                resource_name = t.trim().to_string();
+            }
+        }
+        self.finally_stack.push(vec![DeferredCall {
+            text: format!("{resource_name}.Dispose()"),
+            line,
+        }]);
+        Ok(())
+    }
+
+    fn close_using_declarations(&mut self, count: usize) -> Result<()> {
+        for _ in 0..count {
+            let Some(dispose) = self.finally_stack.pop() else {
+                break;
+            };
+            if self.flow_active {
+                for d in &dispose {
+                    let b = self.new_block();
+                    self.cfg
+                        .add_edge(self.current_block, b, CfgEdgeType::Next);
+                    self.current_block = b;
+                    self.add_statement_to_current(Statement {
+                        kind: StatementKind::Expression,
+                        line: d.line,
+                        text: d.text.clone(),
+                        defined_vars: HashSet::new(),
+                        used_vars: HashSet::new(),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Local function / lambda / anonymous method as a disconnected sub-CFG.
+    fn visit_nested_subcfg(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        let kind = if node.kind() == "local_function_statement" {
+            StatementKind::Declaration
+        } else {
+            StatementKind::Expression
+        };
+        // Parent records the definition only — body is not sequential parent flow.
+        let parent_text = match node.kind() {
+            "local_function_statement" => {
+                let name = node
+                    .child_by_field_name("name")
+                    .and_then(|n| n.utf8_text(source).ok())
+                    .unwrap_or("local")
+                    .trim();
+                format!("local function {name}")
+            }
+            "anonymous_method_expression" => "anonymous method".to_string(),
+            _ => "lambda".to_string(),
+        };
+        self.add_statement_to_current(Statement {
+            kind,
+            line: node.start_position().row + 1,
+            text: parent_text,
+            defined_vars: HashSet::new(),
+            used_vars: HashSet::new(),
+        });
+
+        let body = node
+            .child_by_field_name("body")
+            .or_else(|| find_child_kind(node, "block"))
+            .or_else(|| {
+                // Expression-bodied local function / lambda.
+                node.child_by_field_name("value")
+                    .or_else(|| {
+                        let mut last = None;
+                        let mut c = node.walk();
+                        for ch in node.children(&mut c) {
+                            if ch.is_named()
+                                && !matches!(
+                                    ch.kind(),
+                                    "parameter_list"
+                                        | "implicit_parameter"
+                                        | "identifier"
+                                        | "predefined_type"
+                                        | "generic_name"
+                                        | "modifier"
+                                        | "attribute_list"
+                                )
+                            {
+                                last = Some(ch);
+                            }
+                        }
+                        last
+                    })
+            });
+
+        let Some(body) = body else {
+            return Ok(());
+        };
+
+        // Split so the definition block ends before parent continuation; Jump keeps
+        // the sub-CFG reachable for pruning without making it sequential parent flow.
+        let def_block = self.current_block;
+        let continue_block = self.new_block();
+        if self.flow_active {
+            self.cfg
+                .add_edge(def_block, continue_block, CfgEdgeType::Next);
+        }
+
+        let parent_flow = self.flow_active;
+        let parent_breakable = std::mem::take(&mut self.breakable_stack);
+        let parent_pending_label = self.pending_breakable_label.take();
+        let parent_labels = std::mem::take(&mut self.label_blocks);
+        let parent_fallthrough = self.pending_fallthrough;
+        let parent_switch_ft = self.switch_implicit_fallthrough;
+        let parent_defer = std::mem::take(&mut self.defer_stack);
+        let parent_finally = std::mem::take(&mut self.finally_stack);
+        let parent_try = std::mem::take(&mut self.try_catch_stack);
+        let parent_switch_cases = std::mem::take(&mut self.switch_case_labels);
+        let parent_setjmp = std::mem::take(&mut self.setjmp_sites);
+
+        let sub_entry = self.new_block();
+        let sub_exit = self.new_block();
+        self.cfg
+            .add_edge(def_block, sub_entry, CfgEdgeType::Jump);
+        self.nested_exits.push(sub_exit);
+        self.current_block = sub_entry;
+        self.flow_active = true;
+        self.pending_fallthrough = false;
+        self.switch_implicit_fallthrough = false;
+
+        if is_block_like(body.kind()) {
+            self.visit_block(body, source)?;
+        } else {
+            self.visit_expr_for_control_flow(body, source)?;
+            if self.flow_active {
+                self.add_statement(body, source, StatementKind::Expression)?;
+            }
+            if self.flow_active {
+                self.cfg
+                    .add_edge(self.current_block, sub_exit, CfgEdgeType::Return);
+                self.flow_active = false;
+            }
+        }
+        if self.flow_active {
+            self.cfg
+                .add_edge(self.current_block, sub_exit, CfgEdgeType::Next);
+        }
+        self.nested_exits.pop();
+
+        self.current_block = continue_block;
+        self.flow_active = parent_flow;
+        self.breakable_stack = parent_breakable;
+        self.pending_breakable_label = parent_pending_label;
+        self.label_blocks = parent_labels;
+        self.pending_fallthrough = parent_fallthrough;
+        self.switch_implicit_fallthrough = parent_switch_ft;
+        self.defer_stack = parent_defer;
+        self.finally_stack = parent_finally;
+        self.try_catch_stack = parent_try;
+        self.switch_case_labels = parent_switch_cases;
+        self.setjmp_sites = parent_setjmp;
+        Ok(())
+    }
+
     /// Route current block through deferred calls (LIFO) then a terminal exit edge.
     fn unwind_defers_to_exit(&mut self, terminal: CfgEdgeType) {
         let deferred: Vec<_> = self.defer_stack.iter().rev().cloned().collect();
@@ -1401,6 +1913,11 @@ impl<'a> CfgBuilder<'a> {
                 used_vars: HashSet::new(),
             });
             prev = b;
+        }
+        if let Some(&nested_exit) = self.nested_exits.last() {
+            self.cfg.add_edge(prev, nested_exit, terminal);
+            self.flow_active = false;
+            return;
         }
         let exit = self.new_block();
         self.cfg.add_edge(prev, exit, terminal);
@@ -1500,6 +2017,37 @@ impl<'a> CfgBuilder<'a> {
 
     fn visit_goto(&mut self, node: Node, source: &[u8]) -> Result<()> {
         self.add_statement(node, source, StatementKind::Jump)?;
+        let text = node.utf8_text(source).unwrap_or("").trim().to_string();
+
+        // C# `goto case X;` / `goto default;`
+        if text.starts_with("goto default") {
+            if let Some(target) = self
+                .switch_case_labels
+                .last()
+                .and_then(|m| m.get("default").copied())
+            {
+                self.cfg
+                    .add_edge(self.current_block, target, CfgEdgeType::Jump);
+            }
+            self.flow_active = false;
+            self.current_block = self.new_block();
+            return Ok(());
+        }
+        if text.starts_with("goto case") {
+            let key = goto_case_key(node, source);
+            if let Some(target) = key.and_then(|k| {
+                self.switch_case_labels
+                    .last()
+                    .and_then(|m| m.get(&k).copied())
+            }) {
+                self.cfg
+                    .add_edge(self.current_block, target, CfgEdgeType::Jump);
+            }
+            self.flow_active = false;
+            self.current_block = self.new_block();
+            return Ok(());
+        }
+
         let label = node
             .child_by_field_name("label")
             .or_else(|| node.named_child(0))
@@ -1896,28 +2444,40 @@ impl<'a> CfgBuilder<'a> {
             return Ok(());
         }
 
+        // Pre-create case blocks so `goto case` / `goto default` can resolve forward.
+        self.switch_case_labels.push(HashMap::new());
+        let mut case_blocks: Vec<BlockId> = Vec::with_capacity(cases.len());
         let mut has_default = false;
-        let mut any_reaches_merge = false;
-        let mut fallthrough_from: Option<BlockId> = None;
-        let prev_implicit = self.switch_implicit_fallthrough;
         for case in &cases {
-            // Java classic groups and C `case_statement` fall through by default.
-            self.switch_implicit_fallthrough = matches!(
-                case.kind(),
-                "switch_block_statement_group" | "case_statement" | "default_statement"
-            );
+            let case_block = self.new_block();
+            case_blocks.push(case_block);
             let is_default = is_switch_default_case(*case, source);
             if is_default {
                 has_default = true;
             }
-
-            let case_block = self.new_block();
+            if let Some(map) = self.switch_case_labels.last_mut() {
+                for key in switch_case_keys(*case, source) {
+                    map.insert(key, case_block);
+                }
+            }
             let edge = if is_default {
                 CfgEdgeType::IfFalse
             } else {
                 CfgEdgeType::IfTrue
             };
             self.cfg.add_edge(cond_block, case_block, edge);
+        }
+
+        let mut any_reaches_merge = false;
+        let mut fallthrough_from: Option<BlockId> = None;
+        let prev_implicit = self.switch_implicit_fallthrough;
+        for (case, case_block) in cases.iter().zip(case_blocks.iter().copied()) {
+            // Java classic groups and C `case_statement` fall through by default.
+            self.switch_implicit_fallthrough = matches!(
+                case.kind(),
+                "switch_block_statement_group" | "case_statement" | "default_statement"
+            );
+
             if let Some(src) = fallthrough_from.take() {
                 self.cfg.add_edge(src, case_block, CfgEdgeType::Jump);
             }
@@ -1946,14 +2506,121 @@ impl<'a> CfgBuilder<'a> {
 
         if !has_default {
             let default_block = self.new_block();
+            if let Some(map) = self.switch_case_labels.last_mut() {
+                map.insert("default".to_string(), default_block);
+            }
             self.cfg
                 .add_edge(cond_block, default_block, CfgEdgeType::IfFalse);
             self.cfg.add_edge(default_block, merge, CfgEdgeType::Next);
             any_reaches_merge = true;
         }
 
+        self.switch_case_labels.pop();
         self.breakable_stack.pop();
         self.flow_active = any_reaches_merge;
+        self.current_block = merge;
+        Ok(())
+    }
+
+    /// C# `x switch { pat => val, _ => other }` — multi-way value branch (no fallthrough).
+    /// Java `switch` expressions reuse `switch_expression` but use statement groups/rules —
+    /// those fall through to [`Self::visit_switch`].
+    fn visit_switch_expression(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        let mut arms = Vec::new();
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.kind() == "switch_expression_arm" {
+                arms.push(child);
+            }
+        }
+        if arms.is_empty() {
+            return self.visit_switch(node, source);
+        }
+
+        let subject = node
+            .child_by_field_name("value")
+            .or_else(|| node.named_child(0))
+            .and_then(|n| n.utf8_text(source).ok())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "switch".to_string());
+        self.add_statement_to_current(Statement {
+            kind: StatementKind::Branch,
+            line: node.start_position().row + 1,
+            text: subject,
+            defined_vars: HashSet::new(),
+            used_vars: HashSet::new(),
+        });
+        let cond_block = self.current_block;
+        let merge = self.new_block();
+
+        let mut pending_fail: Option<BlockId> = None;
+        for arm in arms {
+            let test = self.new_block();
+            if let Some(fail) = pending_fail.take() {
+                self.cfg.add_edge(fail, test, CfgEdgeType::Next);
+            } else {
+                self.cfg
+                    .add_edge(cond_block, test, CfgEdgeType::IfTrue);
+            }
+            self.flow_active = true;
+            self.current_block = test;
+
+            let body = self.new_block();
+            let fail = self.new_block();
+
+            // Optional `when` guard on the arm.
+            let when = find_child_kind(arm, "when_clause");
+            let pat_text = arm
+                .child_by_field_name("pattern")
+                .or_else(|| arm.named_child(0))
+                .and_then(|p| p.utf8_text(source).ok())
+                .map(|s| s.trim().to_string())
+                .unwrap_or_else(|| "arm".to_string());
+            self.add_statement_to_current(Statement {
+                kind: StatementKind::Branch,
+                line: arm.start_position().row + 1,
+                text: pat_text,
+                defined_vars: HashSet::new(),
+                used_vars: HashSet::new(),
+            });
+            if let Some(w) = when {
+                let mid = self.new_block();
+                self.cfg.add_edge(test, mid, CfgEdgeType::IfTrue);
+                self.cfg.add_edge(test, fail, CfgEdgeType::IfFalse);
+                self.flow_active = true;
+                self.current_block = mid;
+                let cond = w
+                    .child_by_field_name("condition")
+                    .or_else(|| w.child_by_field_name("value"))
+                    .or_else(|| w.named_child(0))
+                    .unwrap_or(w);
+                self.wire_condition(cond, source, body, fail)?;
+            } else {
+                self.cfg.add_edge(test, body, CfgEdgeType::IfTrue);
+                self.cfg.add_edge(test, fail, CfgEdgeType::IfFalse);
+            }
+            pending_fail = Some(fail);
+
+            self.flow_active = true;
+            self.current_block = body;
+            if let Some(value) = arm.child_by_field_name("value") {
+                self.visit_expr_for_control_flow(value, source)?;
+                if self.flow_active {
+                    self.add_statement(value, source, StatementKind::Expression)?;
+                }
+            }
+            if self.flow_active {
+                self.cfg
+                    .add_edge(self.current_block, merge, CfgEdgeType::Next);
+            }
+        }
+
+        if let Some(fail) = pending_fail {
+            self.cfg.add_edge(fail, merge, CfgEdgeType::Next);
+        }
+
+        self.flow_active = true;
         self.current_block = merge;
         Ok(())
     }
@@ -1965,6 +2632,56 @@ impl<'a> CfgBuilder<'a> {
             return Ok(());
         }
         match case.kind() {
+            "switch_section" => {
+                let mut when: Option<Node> = None;
+                let mut stmts: Vec<Node> = Vec::new();
+                let mut c = case.walk();
+                for child in case.children(&mut c) {
+                    if !child.is_named() {
+                        // Skip `case` / `default` / `:` tokens.
+                        continue;
+                    }
+                    match child.kind() {
+                        "case_switch_label"
+                        | "case_pattern_switch_label"
+                        | "default_switch_label"
+                        | "switch_label"
+                        | "constant_pattern"
+                        | "declaration_pattern"
+                        | "relational_pattern"
+                        | "var_pattern"
+                        | "recursive_pattern"
+                        | "list_pattern"
+                        | "type_pattern" => {
+                            // `when` may be nested under the pattern label.
+                            if when.is_none() {
+                                when = find_child_kind(child, "when_clause");
+                            }
+                        }
+                        "when_clause" => when = Some(child),
+                        _ => stmts.push(child),
+                    }
+                }
+                if let Some(w) = when {
+                    let body = self.new_block();
+                    let fail = self
+                        .breakable_stack
+                        .last()
+                        .map(|b| b.exit)
+                        .unwrap_or_else(|| self.new_block());
+                    let cond = w
+                        .child_by_field_name("condition")
+                        .or_else(|| w.child_by_field_name("value"))
+                        .or_else(|| w.named_child(0))
+                        .unwrap_or(w);
+                    self.wire_condition(cond, source, body, fail)?;
+                    self.flow_active = true;
+                    self.current_block = body;
+                }
+                for stmt in stmts {
+                    self.visit_statement(stmt, source)?;
+                }
+            }
             "switch_block_statement_group" | "switch_rule" => {
                 let mut c = case.walk();
                 for child in case.children(&mut c) {
@@ -2074,6 +2791,29 @@ impl<'a> CfgBuilder<'a> {
             let handler = catch_entries[i];
             self.flow_active = true;
             self.current_block = handler;
+
+            // C# `catch (E e) when (cond)` — filter before catch body.
+            if let Some(filter) = find_child_kind(*catch_node, "catch_filter_clause")
+                .or_else(|| find_child_kind(*catch_node, "when_clause"))
+            {
+                let body = self.new_block();
+                let fail = self.new_block();
+                let cond = filter
+                    .child_by_field_name("filter")
+                    .or_else(|| filter.child_by_field_name("condition"))
+                    .or_else(|| filter.child_by_field_name("value"))
+                    .or_else(|| filter.named_child(0))
+                    .unwrap_or(filter);
+                self.wire_condition(cond, source, body, fail)?;
+                // Filter fail → rethrow through finallies.
+                self.flow_active = true;
+                self.current_block = fail;
+                self.unwind_finallies(source)?;
+                self.unwind_defers_to_exit(CfgEdgeType::Exception);
+                self.flow_active = true;
+                self.current_block = body;
+            }
+
             if let Some(block) = catch_node.child_by_field_name("body") {
                 self.visit_block(block, source)?;
             } else if catch_node.kind() == "catch_clause" {
@@ -2253,7 +2993,14 @@ fn is_switch_default_case(case: Node, source: &[u8]) -> bool {
     }
     let mut c = case.walk();
     for child in case.children(&mut c) {
-        if child.kind() == "switch_label" {
+        // C# `switch_section`: bare `default` token (unnamed) or label nodes.
+        if child.kind() == "default" || child.kind() == "default_switch_label" {
+            return true;
+        }
+        if matches!(
+            child.kind(),
+            "switch_label" | "default_label"
+        ) {
             if let Ok(t) = child.utf8_text(source) {
                 if t.trim().starts_with("default") {
                     return true;
@@ -2397,6 +3144,153 @@ fn logical_operator<'a>(node: Node<'a>, source: &'a [u8]) -> Option<&'a str> {
         Some(text)
     } else {
         None
+    }
+}
+
+fn null_coalesce_operator(node: Node, source: &[u8]) -> bool {
+    if node.kind() != "binary_expression" {
+        return false;
+    }
+    node.child_by_field_name("operator")
+        .and_then(|op| op.utf8_text(source).ok())
+        .is_some_and(|t| t == "??")
+}
+
+fn is_csharp_using_declaration(node: Node, source: &[u8]) -> bool {
+    if node.kind() != "local_declaration_statement" {
+        return false;
+    }
+    let mut c = node.walk();
+    for ch in node.children(&mut c) {
+        if ch.kind() == "using" {
+            return true;
+        }
+    }
+    node.utf8_text(source)
+        .ok()
+        .is_some_and(|t| t.trim_start().starts_with("using "))
+}
+
+fn goto_case_key(node: Node, source: &[u8]) -> Option<String> {
+    let mut c = node.walk();
+    for ch in node.children(&mut c) {
+        if !ch.is_named() {
+            continue;
+        }
+        if matches!(
+            ch.kind(),
+            "integer_literal"
+                | "real_literal"
+                | "string_literal"
+                | "character_literal"
+                | "boolean_literal"
+                | "null_literal"
+                | "identifier"
+                | "prefix_unary_expression"
+        ) {
+            return ch.utf8_text(source).ok().map(|s| s.trim().to_string());
+        }
+    }
+    // Fallback: parse `goto case 2;`
+    let text = node.utf8_text(source).ok()?.trim();
+    let rest = text.strip_prefix("goto case")?.trim();
+    let key = rest.trim_end_matches(';').trim();
+    if key.is_empty() {
+        None
+    } else {
+        Some(key.to_string())
+    }
+}
+
+fn switch_case_keys(case: Node, source: &[u8]) -> Vec<String> {
+    if is_switch_default_case(case, source) {
+        return vec!["default".to_string()];
+    }
+    let mut keys = Vec::new();
+    let mut c = case.walk();
+    for child in case.children(&mut c) {
+        match child.kind() {
+            // C# modern grammar: `case 1:` → `case` + `constant_pattern` + `:`
+            "constant_pattern" => {
+                if let Ok(t) = child.utf8_text(source) {
+                    let t = t.trim();
+                    if !t.is_empty() {
+                        keys.push(t.to_string());
+                    }
+                }
+            }
+            "case_switch_label" | "switch_label" | "case_pattern_switch_label" => {
+                if let Some(k) = case_label_constant(child, source) {
+                    keys.push(k);
+                }
+            }
+            "case_statement" => {
+                if let Some(v) = child.child_by_field_name("value") {
+                    if let Ok(t) = v.utf8_text(source) {
+                        keys.push(t.trim().to_string());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    if keys.is_empty() {
+        if let Some(v) = case.child_by_field_name("value") {
+            if let Ok(t) = v.utf8_text(source) {
+                keys.push(t.trim().to_string());
+            }
+        }
+    }
+    keys
+}
+
+fn case_label_constant(label: Node, source: &[u8]) -> Option<String> {
+    let mut c = label.walk();
+    for ch in label.children(&mut c) {
+        if !ch.is_named() {
+            continue;
+        }
+        if matches!(
+            ch.kind(),
+            "integer_literal"
+                | "real_literal"
+                | "string_literal"
+                | "character_literal"
+                | "boolean_literal"
+                | "null_literal"
+                | "identifier"
+                | "prefix_unary_expression"
+                | "constant_pattern"
+        ) {
+            return ch.utf8_text(source).ok().map(|s| s.trim().to_string());
+        }
+        // `constant_pattern` wraps the literal.
+        if let Some(inner) = ch.named_child(0) {
+            if matches!(
+                inner.kind(),
+                "integer_literal"
+                    | "real_literal"
+                    | "string_literal"
+                    | "character_literal"
+                    | "boolean_literal"
+                    | "null_literal"
+                    | "identifier"
+            ) {
+                return inner.utf8_text(source).ok().map(|s| s.trim().to_string());
+            }
+        }
+    }
+    // `case 1:` text fallback
+    let text = label.utf8_text(source).ok()?.trim();
+    let rest = text
+        .strip_prefix("case")?
+        .trim()
+        .trim_end_matches(':')
+        .trim();
+    if rest.is_empty() || rest.starts_with("var") || rest.contains(' ') {
+        None
+    } else {
+        Some(rest.to_string())
     }
 }
 
@@ -3418,6 +4312,10 @@ public class Demo {
 "#;
         let cfg = build_cfg_for_function("csharp", code, "Abs").unwrap();
         assert!(cfg.blocks.len() >= 4);
+        assert!(cfg
+            .edges
+            .iter()
+            .any(|e| e.edge_type == CfgEdgeType::IfTrue));
     }
 
     #[test]
@@ -3435,6 +4333,619 @@ public class Demo {
 "#;
         let cfg = build_cfg_for_function("csharp", code, "Sum").unwrap();
         assert!(cfg.has_cycle());
+    }
+
+    fn cs_texts(cfg: &ControlFlowGraph) -> Vec<String> {
+        cfg.blocks
+            .values()
+            .flat_map(|b| b.statements.iter().map(|s| s.text.clone()))
+            .collect()
+    }
+
+    fn cs_kinds(cfg: &ControlFlowGraph) -> Vec<StatementKind> {
+        cfg.blocks
+            .values()
+            .flat_map(|b| b.statements.iter().map(|s| s.kind))
+            .collect()
+    }
+
+    fn cs_block_ids(cfg: &ControlFlowGraph, needle: &str) -> Vec<uuid::Uuid> {
+        cfg.blocks
+            .values()
+            .filter(|b| b.statements.iter().any(|s| s.text.contains(needle)))
+            .map(|b| b.id)
+            .collect()
+    }
+
+    #[test]
+    fn test_csharp_short_circuit_and() {
+        let code = r#"
+public class Demo {
+    public int Sc(bool a, bool b) {
+        if (a && b) { return 1; }
+        return 0;
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("csharp", code, "Sc").unwrap();
+        let texts = cs_texts(&cfg);
+        assert!(texts.iter().any(|t| t.trim() == "a"), "got {texts:?}");
+        assert!(texts.iter().any(|t| t.trim() == "b"), "got {texts:?}");
+    }
+
+    #[test]
+    fn test_csharp_for_continue_to_update() {
+        let code = r#"
+public class Demo {
+    public int Sum(int n) {
+        int total = 0;
+        for (int i = 0; i < n; i++) {
+            if (i == 1) { continue; }
+            total += i;
+        }
+        return total;
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("csharp", code, "Sum").unwrap();
+        let cont = cs_block_ids(&cfg, "continue");
+        let updates = cs_block_ids(&cfg, "i++");
+        assert!(
+            cont.iter().any(|c| {
+                cfg.edges.iter().any(|e| {
+                    e.from == *c && updates.contains(&e.to) && e.edge_type == CfgEdgeType::Jump
+                })
+            }),
+            "continue must Jump to i++"
+        );
+    }
+
+    #[test]
+    fn test_csharp_foreach_cycle() {
+        let code = r#"
+public class Demo {
+    public int Fe(int[] a) {
+        int t = 0;
+        foreach (var v in a) {
+            t += v;
+        }
+        return t;
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("csharp", code, "Fe").unwrap();
+        assert!(cfg.has_cycle(), "foreach must cycle");
+        assert!(
+            cs_texts(&cfg).iter().any(|t| t.contains("t += v") || t.contains("t+=v")),
+            "body must lower, got {:?}",
+            cs_texts(&cfg)
+        );
+        assert!(
+            !cs_texts(&cfg)
+                .iter()
+                .any(|t| t.trim_start().starts_with("foreach")),
+            "foreach must not stay opaque, got {:?}",
+            cs_texts(&cfg)
+        );
+    }
+
+    #[test]
+    fn test_csharp_switch_sections_and_when() {
+        let code = r#"
+public class Demo {
+    public int Sw(int x) {
+        switch (x) {
+            case 1:
+                return 10;
+            case int i when i > 0:
+                return i;
+            default:
+                return 0;
+        }
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("csharp", code, "Sw").unwrap();
+        assert!(
+            cs_kinds(&cfg)
+                .iter()
+                .filter(|k| **k == StatementKind::Return)
+                .count()
+                >= 3,
+            "section returns must lower, kinds={:?}",
+            cs_kinds(&cfg)
+        );
+        assert!(
+            cs_texts(&cfg)
+                .iter()
+                .any(|t| t.contains("i > 0") || t.trim() == "i > 0"),
+            "when guard must lower, got {:?}",
+            cs_texts(&cfg)
+        );
+    }
+
+    #[test]
+    fn test_csharp_switch_expression_arms() {
+        let code = r#"
+public class Demo {
+    public string Se(int x) {
+        return x switch {
+            > 0 => "pos",
+            _ => "neg"
+        };
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("csharp", code, "Se").unwrap();
+        assert!(
+            cfg.edges
+                .iter()
+                .filter(|e| e.edge_type == CfgEdgeType::IfTrue)
+                .count()
+                >= 1,
+            "switch expression needs arm fan-out"
+        );
+        assert!(
+            !cs_texts(&cfg)
+                .iter()
+                .any(|t| t.contains("> 0 =>") && t.contains("_ =>")),
+            "must not stay one blob, got {:?}",
+            cs_texts(&cfg)
+        );
+    }
+
+    #[test]
+    fn test_csharp_null_coalescing() {
+        let code = r#"
+public class Demo {
+    public string Nc(string a, string b) {
+        return a ?? b;
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("csharp", code, "Nc").unwrap();
+        assert!(
+            cfg.edges
+                .iter()
+                .any(|e| e.edge_type == CfgEdgeType::IfTrue)
+                && cfg
+                    .edges
+                    .iter()
+                    .any(|e| e.edge_type == CfgEdgeType::IfFalse),
+            "?? must split"
+        );
+        assert!(
+            cs_texts(&cfg).iter().any(|t| t.contains("a") || t.contains("??")),
+            "?? operands must appear, got {:?}",
+            cs_texts(&cfg)
+        );
+    }
+
+    #[test]
+    fn test_csharp_null_conditional() {
+        let code = r#"
+public class Demo {
+    public int Na(Demo d) {
+        return d?.GetHashCode() ?? 0;
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("csharp", code, "Na").unwrap();
+        assert!(
+            cfg.edges
+                .iter()
+                .any(|e| e.edge_type == CfgEdgeType::IfTrue)
+                && cfg
+                    .edges
+                    .iter()
+                    .any(|e| e.edge_type == CfgEdgeType::IfFalse),
+            "?. must split"
+        );
+    }
+
+    #[test]
+    fn test_csharp_try_catch_when_finally() {
+        let code = r#"
+public class Demo {
+    public int Tw() {
+        try {
+            throw new System.Exception();
+        } catch (System.Exception e) when (e != null) {
+            return 1;
+        } finally {
+            System.Console.WriteLine("cleanup");
+        }
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("csharp", code, "Tw").unwrap();
+        assert!(
+            cfg.edges
+                .iter()
+                .any(|e| e.edge_type == CfgEdgeType::Exception),
+            "try/catch Exception edge"
+        );
+        assert!(
+            cs_texts(&cfg)
+                .iter()
+                .any(|t| t.contains("cleanup") || t.contains("WriteLine")),
+            "finally must appear on throw/return path, got {:?}",
+            cs_texts(&cfg)
+        );
+        assert!(
+            cs_texts(&cfg)
+                .iter()
+                .any(|t| t.contains("e != null") || t.contains("e!=null")),
+            "catch when filter must lower, got {:?}",
+            cs_texts(&cfg)
+        );
+    }
+
+    #[test]
+    fn test_csharp_using_dispose_on_return() {
+        let code = r#"
+public class Demo {
+    public int Us() {
+        using (var r = new System.IO.StringReader("")) {
+            return 1;
+        }
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("csharp", code, "Us").unwrap();
+        assert!(
+            cs_texts(&cfg)
+                .iter()
+                .any(|t| t.contains("Dispose") || t.contains("r.Dispose")),
+            "using must emit Dispose on exit, got {:?}",
+            cs_texts(&cfg)
+        );
+        let ret = cs_block_ids(&cfg, "return 1");
+        let disp = cs_block_ids(&cfg, "Dispose");
+        assert!(!ret.is_empty() && !disp.is_empty());
+        assert!(
+            ret.iter().any(|r| {
+                disp.iter().any(|d| {
+                    use std::collections::{HashSet, VecDeque};
+                    let mut seen = HashSet::new();
+                    let mut q = VecDeque::from([*r]);
+                    while let Some(n) = q.pop_front() {
+                        if n == *d {
+                            return true;
+                        }
+                        if !seen.insert(n) {
+                            continue;
+                        }
+                        for e in &cfg.edges {
+                            if e.from == n {
+                                q.push_back(e.to);
+                            }
+                        }
+                    }
+                    false
+                })
+            }),
+            "return must reach Dispose"
+        );
+    }
+
+    #[test]
+    fn test_csharp_lock_exit_on_return() {
+        let code = r#"
+public class Demo {
+    public int Lk(object o) {
+        lock (o) {
+            return 1;
+        }
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("csharp", code, "Lk").unwrap();
+        assert!(
+            cs_texts(&cfg)
+                .iter()
+                .any(|t| t.contains("Monitor.Exit") || t.contains("Exit")),
+            "lock must emit Monitor.Exit, got {:?}",
+            cs_texts(&cfg)
+        );
+    }
+
+    #[test]
+    fn test_csharp_await_splits_block() {
+        let code = r#"
+public class Demo {
+    public async System.Threading.Tasks.Task<int> Aw() {
+        await System.Threading.Tasks.Task.Delay(1);
+        return 1;
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("csharp", code, "Aw").unwrap();
+        assert!(
+            cs_texts(&cfg).iter().any(|t| t.contains("await")),
+            "await must appear, got {:?}",
+            cs_texts(&cfg)
+        );
+        assert!(cfg.blocks.len() >= 3, "await should split blocks");
+    }
+
+    #[test]
+    fn test_csharp_yield_return_and_break() {
+        let code = r#"
+public class Demo {
+    public System.Collections.Generic.IEnumerable<int> Y() {
+        yield return 1;
+        yield break;
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("csharp", code, "Y").unwrap();
+        assert!(
+            cs_texts(&cfg).iter().any(|t| t.contains("yield return")),
+            "yield return must appear, got {:?}",
+            cs_texts(&cfg)
+        );
+        assert!(
+            cfg.edges.iter().any(|e| {
+                matches!(
+                    e.edge_type,
+                    CfgEdgeType::Return | CfgEdgeType::Exception | CfgEdgeType::Jump
+                )
+            }),
+            "yield break must terminate"
+        );
+    }
+
+    #[test]
+    fn test_csharp_goto_and_label() {
+        let code = r#"
+public class Demo {
+    public int G(int x) {
+        if (x < 0) { goto done; }
+        x++;
+        done:
+        return x;
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("csharp", code, "G").unwrap();
+        let froms = cs_block_ids(&cfg, "goto done");
+        assert!(!froms.is_empty());
+        assert!(
+            cfg.edges
+                .iter()
+                .any(|e| froms.contains(&e.from) && e.edge_type == CfgEdgeType::Jump),
+            "goto must Jump"
+        );
+    }
+
+    #[test]
+    fn test_csharp_using_declaration_dispose() {
+        let code = r#"
+public class Demo {
+    public int Ud() {
+        using var r = new System.IO.StringReader("");
+        return 1;
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("csharp", code, "Ud").unwrap();
+        assert!(
+            cs_texts(&cfg)
+                .iter()
+                .any(|t| t.contains("Dispose") || t.contains("r.Dispose")),
+            "using declaration must Dispose on exit, got {:?}",
+            cs_texts(&cfg)
+        );
+        let ret = cs_block_ids(&cfg, "return 1");
+        let disp = cs_block_ids(&cfg, "Dispose");
+        assert!(!ret.is_empty() && !disp.is_empty());
+        assert!(
+            ret.iter().any(|r| {
+                disp.iter().any(|d| {
+                    use std::collections::{HashSet, VecDeque};
+                    let mut seen = HashSet::new();
+                    let mut q = VecDeque::from([*r]);
+                    while let Some(n) = q.pop_front() {
+                        if n == *d {
+                            return true;
+                        }
+                        if !seen.insert(n) {
+                            continue;
+                        }
+                        for e in &cfg.edges {
+                            if e.from == n {
+                                q.push_back(e.to);
+                            }
+                        }
+                    }
+                    false
+                })
+            }),
+            "return must reach Dispose"
+        );
+    }
+
+    #[test]
+    fn test_csharp_goto_case_and_default() {
+        let code = r#"
+public class Demo {
+    public int Gc(int x) {
+        switch (x) {
+            case 1:
+                goto case 2;
+            case 2:
+                goto default;
+            default:
+                return 0;
+        }
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("csharp", code, "Gc").unwrap();
+        let goto_case = cs_block_ids(&cfg, "goto case 2");
+        let goto_def = cs_block_ids(&cfg, "goto default");
+        let case2 = cs_block_ids(&cfg, "goto default");
+        let ret0 = cs_block_ids(&cfg, "return 0");
+        assert!(!goto_case.is_empty() && !goto_def.is_empty());
+        assert!(
+            goto_case.iter().any(|g| {
+                cfg.edges.iter().any(|e| {
+                    e.from == *g
+                        && e.edge_type == CfgEdgeType::Jump
+                        && case2.contains(&e.to)
+                })
+            }),
+            "goto case 2 must Jump into case 2 block"
+        );
+        assert!(
+            goto_def.iter().any(|g| {
+                ret0.iter().any(|r| {
+                    cfg.edges.iter().any(|e| {
+                        e.from == *g && e.to == *r && e.edge_type == CfgEdgeType::Jump
+                    }) || {
+                        use std::collections::{HashSet, VecDeque};
+                        let mut seen = HashSet::new();
+                        let mut q = VecDeque::from([*g]);
+                        while let Some(n) = q.pop_front() {
+                            if n == *r {
+                                return true;
+                            }
+                            if !seen.insert(n) {
+                                continue;
+                            }
+                            for e in &cfg.edges {
+                                if e.from == n && e.edge_type == CfgEdgeType::Jump {
+                                    q.push_back(e.to);
+                                }
+                            }
+                        }
+                        false
+                    }
+                })
+            }),
+            "goto default must reach default body"
+        );
+    }
+
+    #[test]
+    fn test_csharp_local_function_is_subcfg() {
+        let code = r#"
+public class Demo {
+    public int Lf() {
+        int Inner(int y) {
+            return y + 1;
+        }
+        return Inner(1);
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("csharp", code, "Lf").unwrap();
+        assert!(
+            cs_texts(&cfg)
+                .iter()
+                .any(|t| t.contains("Inner") && t.contains("y + 1") || t.contains("return y + 1")),
+            "local function body must be lowered, got {:?}",
+            cs_texts(&cfg)
+        );
+        let parent_ret = cs_block_ids(&cfg, "return Inner(1)");
+        let inner_ret = cs_block_ids(&cfg, "return y + 1");
+        assert!(!parent_ret.is_empty() && !inner_ret.is_empty());
+        // Parent sequential flow must not enter Inner's body before calling it.
+        assert!(
+            !parent_ret.iter().any(|p| {
+                inner_ret.iter().any(|i| {
+                    cfg.edges.iter().any(|e| e.from == *p && e.to == *i)
+                })
+            }),
+            "parent return must not fall into Inner body"
+        );
+        // Inner body should not be reachable from entry via Next-only path through parent return.
+        let entry = cfg.entry;
+        assert!(
+            !inner_ret.iter().any(|i| {
+                use std::collections::{HashSet, VecDeque};
+                let mut seen = HashSet::new();
+                let mut q = VecDeque::from([entry]);
+                while let Some(n) = q.pop_front() {
+                    if n == *i {
+                        return true;
+                    }
+                    if !seen.insert(n) {
+                        continue;
+                    }
+                    for e in &cfg.edges {
+                        if e.from == n
+                            && matches!(
+                                e.edge_type,
+                                CfgEdgeType::Next | CfgEdgeType::IfTrue | CfgEdgeType::IfFalse
+                            )
+                        {
+                            q.push_back(e.to);
+                        }
+                    }
+                }
+                false
+            }),
+            "Inner body must be a disconnected sub-CFG (not on parent Next path)"
+        );
+    }
+
+    #[test]
+    fn test_csharp_lambda_is_subcfg() {
+        let code = r#"
+public class Demo {
+    public System.Func<int,int> Lam() {
+        return x => {
+            if (x > 0) { return x; }
+            return -x;
+        };
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("csharp", code, "Lam").unwrap();
+        assert!(
+            cfg.edges
+                .iter()
+                .any(|e| e.edge_type == CfgEdgeType::IfTrue),
+            "lambda body if must lower, edges={:?}",
+            cfg.edges.iter().map(|e| e.edge_type).collect::<Vec<_>>()
+        );
+        assert!(
+            cs_kinds(&cfg)
+                .iter()
+                .filter(|k| **k == StatementKind::Return)
+                .count()
+                >= 2,
+            "lambda returns must lower, kinds={:?}",
+            cs_kinds(&cfg)
+        );
+    }
+
+    #[test]
+    fn test_csharp_await_suspend_and_resume() {
+        let code = r#"
+public class Demo {
+    public async System.Threading.Tasks.Task<int> Aw() {
+        await System.Threading.Tasks.Task.Delay(1);
+        return 1;
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("csharp", code, "Aw").unwrap();
+        let await_blocks = cs_block_ids(&cfg, "await");
+        assert!(!await_blocks.is_empty());
+        assert!(
+            await_blocks.iter().any(|a| {
+                cfg.edges.iter().any(|e| {
+                    e.from == *a && e.edge_type == CfgEdgeType::IfTrue
+                }) && cfg.edges.iter().any(|e| {
+                    e.from == *a
+                        && matches!(e.edge_type, CfgEdgeType::IfFalse | CfgEdgeType::Return)
+                })
+            }),
+            "await must split resume (IfTrue) vs suspend (IfFalse/Return)"
+        );
     }
 
     #[test]

--- a/crates/rbuilder-analysis/src/cfg_builder.rs
+++ b/crates/rbuilder-analysis/src/cfg_builder.rs
@@ -166,6 +166,8 @@ struct CfgBuilder<'a> {
     try_catch_stack: Vec<Vec<BlockId>>,
     /// When true, leaving a switch case falls into the next case (Java classic switch).
     switch_implicit_fallthrough: bool,
+    /// C `setjmp` sites in this function (approx targets for `longjmp`).
+    setjmp_sites: Vec<BlockId>,
 }
 
 struct BreakableContext {
@@ -199,6 +201,7 @@ impl<'a> CfgBuilder<'a> {
             finally_stack: Vec::new(),
             try_catch_stack: Vec::new(),
             switch_implicit_fallthrough: false,
+            setjmp_sites: Vec::new(),
         }
     }
 
@@ -363,6 +366,9 @@ impl<'a> CfgBuilder<'a> {
             // Expression statement
             "expression_statement" => self.visit_expression_stmt(node, source),
 
+            // C ternary `cond ? a : b`
+            "conditional_expression" => self.visit_conditional_expression(node, source),
+
             // Rust match
             "match_expression" => self.visit_match(node, source),
 
@@ -422,7 +428,9 @@ impl<'a> CfgBuilder<'a> {
             | "for_statement" | "for_expression" | "for_in_expression" | "loop_expression"
             | "match_expression" | "return_statement" | "return_expression"
             | "try_expression" | "await_expression" | "break_expression" | "continue_expression"
-            | "macro_invocation" => self.visit_statement(inner, source),
+            | "macro_invocation" | "conditional_expression" => {
+                self.visit_statement(inner, source)
+            }
             _ => {
                 self.visit_expr_for_control_flow(inner, source)?;
                 if !self.flow_active {
@@ -430,8 +438,15 @@ impl<'a> CfgBuilder<'a> {
                 }
                 let kind = Self::classify_expression(inner, source);
                 self.add_statement(inner, source, kind)?;
-                if is_panic_call(inner, source) || is_diverging_macro(inner, source) {
+                if is_panic_call(inner, source)
+                    || is_diverging_macro(inner, source)
+                    || is_terminating_call(inner, source)
+                {
                     self.unwind_defers_to_exit(CfgEdgeType::Exception);
+                } else if is_longjmp_call(inner, source) {
+                    self.wire_longjmp_edges();
+                } else if is_setjmp_call(inner, source) {
+                    self.setjmp_sites.push(self.current_block);
                 }
                 Ok(())
             }
@@ -449,8 +464,26 @@ impl<'a> CfgBuilder<'a> {
             "if_expression" | "if_statement" | "match_expression" | "loop_expression"
             | "while_expression" | "while_statement" | "for_expression" | "for_statement"
             | "return_expression" | "return_statement" | "break_expression"
-            | "continue_expression" | "macro_invocation" => self.visit_statement(node, source),
+            | "continue_expression" | "macro_invocation" | "conditional_expression" => {
+                self.visit_statement(node, source)
+            }
             _ => {
+                // Detect setjmp/longjmp/abort nested in larger expressions (e.g. if cond).
+                if is_setjmp_call(node, source) {
+                    self.add_statement(node, source, StatementKind::Branch)?;
+                    self.setjmp_sites.push(self.current_block);
+                    return Ok(());
+                }
+                if is_longjmp_call(node, source) {
+                    self.add_statement(node, source, StatementKind::Jump)?;
+                    self.wire_longjmp_edges();
+                    return Ok(());
+                }
+                if is_terminating_call(node, source) {
+                    self.add_statement(node, source, StatementKind::Jump)?;
+                    self.unwind_defers_to_exit(CfgEdgeType::Exception);
+                    return Ok(());
+                }
                 let mut cursor = node.walk();
                 for child in node.children(&mut cursor) {
                     if !child.is_named() {
@@ -469,13 +502,14 @@ impl<'a> CfgBuilder<'a> {
                             | "return_expression"
                             | "break_expression"
                             | "continue_expression"
+                            | "conditional_expression"
+                            | "call_expression"
                     ) {
                         self.visit_expr_for_control_flow(child, source)?;
                         if !self.flow_active {
                             return Ok(());
                         }
                     } else {
-                        // Deep search for nested `?` / await (e.g. in call args).
                         self.visit_expr_for_control_flow(child, source)?;
                         if !self.flow_active {
                             return Ok(());
@@ -485,6 +519,67 @@ impl<'a> CfgBuilder<'a> {
                 Ok(())
             }
         }
+    }
+
+    fn visit_conditional_expression(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        let true_block = self.new_block();
+        let false_block = self.new_block();
+        let merge = self.new_block();
+        if let Some(cond) = node.child_by_field_name("condition") {
+            self.wire_condition(cond, source, true_block, false_block)?;
+        } else {
+            self.add_statement(node, source, StatementKind::Branch)?;
+            self.cfg
+                .add_edge(self.current_block, true_block, CfgEdgeType::IfTrue);
+            self.cfg
+                .add_edge(self.current_block, false_block, CfgEdgeType::IfFalse);
+        }
+
+        self.flow_active = true;
+        self.current_block = true_block;
+        if let Some(cons) = node.child_by_field_name("consequence") {
+            self.visit_expr_for_control_flow(cons, source)?;
+            if self.flow_active {
+                self.add_statement(cons, source, StatementKind::Expression)?;
+            }
+        }
+        let true_reaches = self.flow_active;
+        let true_end = self.current_block;
+
+        self.flow_active = true;
+        self.current_block = false_block;
+        if let Some(alt) = node.child_by_field_name("alternative") {
+            self.visit_expr_for_control_flow(alt, source)?;
+            if self.flow_active {
+                self.add_statement(alt, source, StatementKind::Expression)?;
+            }
+        }
+        let false_reaches = self.flow_active;
+        let false_end = self.current_block;
+
+        if true_reaches {
+            self.cfg.add_edge(true_end, merge, CfgEdgeType::Next);
+        }
+        if false_reaches {
+            self.cfg.add_edge(false_end, merge, CfgEdgeType::Next);
+        }
+        self.flow_active = true_reaches || false_reaches;
+        self.current_block = merge;
+        Ok(())
+    }
+
+    fn wire_longjmp_edges(&mut self) {
+        let sites = self.setjmp_sites.clone();
+        if sites.is_empty() {
+            self.unwind_defers_to_exit(CfgEdgeType::Exception);
+            return;
+        }
+        for site in sites {
+            self.cfg
+                .add_edge(self.current_block, site, CfgEdgeType::Jump);
+        }
+        self.flow_active = false;
+        self.current_block = self.new_block();
     }
 
     fn visit_try_expression(&mut self, node: Node, source: &[u8]) -> Result<()> {
@@ -732,29 +827,34 @@ impl<'a> CfgBuilder<'a> {
             label: self.pending_breakable_label.take(),
         });
 
+        self.flow_active = true;
         self.current_block = body;
         if let Some(body_node) = node.child_by_field_name("body") {
             self.visit_block(body_node, source)?;
         }
-        self.cfg
-            .add_edge(self.current_block, header, CfgEdgeType::Next);
+        if self.flow_active {
+            self.cfg
+                .add_edge(self.current_block, header, CfgEdgeType::Next);
+        }
 
-        self.add_statement_to_current(Statement {
-            kind: StatementKind::Branch,
-            line: node.start_position().row + 1,
-            text: node
-                .child_by_field_name("condition")
-                .and_then(|c| c.utf8_text(source).ok())
-                .unwrap_or("do")
-                .trim()
-                .to_string(),
-            defined_vars: HashSet::new(),
-            used_vars: HashSet::new(),
-        });
-        self.cfg.add_edge(header, body, CfgEdgeType::IfTrue);
-        self.cfg.add_edge(header, exit, CfgEdgeType::IfFalse);
+        self.flow_active = true;
+        self.current_block = header;
+        if let Some(cond) = node.child_by_field_name("condition") {
+            self.wire_condition(cond, source, body, exit)?;
+        } else {
+            self.add_statement_to_current(Statement {
+                kind: StatementKind::Branch,
+                line: node.start_position().row + 1,
+                text: "do".to_string(),
+                defined_vars: HashSet::new(),
+                used_vars: HashSet::new(),
+            });
+            self.cfg.add_edge(header, body, CfgEdgeType::IfTrue);
+            self.cfg.add_edge(header, exit, CfgEdgeType::IfFalse);
+        }
         self.breakable_stack.pop();
 
+        self.flow_active = true;
         self.current_block = exit;
         Ok(())
     }
@@ -1074,6 +1174,34 @@ impl<'a> CfgBuilder<'a> {
             return Ok(());
         }
 
+        // C/C++: `return cond ? a : b;`
+        if let Some(tern) = {
+            let mut found = None;
+            let mut c = node.walk();
+            for ch in node.children(&mut c) {
+                if ch.kind() == "conditional_expression" {
+                    found = Some(ch);
+                    break;
+                }
+            }
+            found
+        } {
+            self.visit_conditional_expression(tern, source)?;
+            if !self.flow_active {
+                return Ok(());
+            }
+            self.add_statement_to_current(Statement {
+                kind: StatementKind::Return,
+                line: node.start_position().row + 1,
+                text: "return".to_string(),
+                defined_vars: HashSet::new(),
+                used_vars: HashSet::new(),
+            });
+            self.unwind_finallies(source)?;
+            self.unwind_defers_to_exit(CfgEdgeType::Return);
+            return Ok(());
+        }
+
         self.add_statement(node, source, StatementKind::Return)?;
         self.unwind_finallies(source)?;
         self.unwind_defers_to_exit(CfgEdgeType::Return);
@@ -1256,22 +1384,27 @@ impl<'a> CfgBuilder<'a> {
 
     fn visit_goto(&mut self, node: Node, source: &[u8]) -> Result<()> {
         self.add_statement(node, source, StatementKind::Jump)?;
-        let label = {
-            let mut found = None;
-            if let Some(n) = node.named_child(0) {
-                found = n.utf8_text(source).ok().map(|s| s.trim().to_string());
-            }
-            if found.is_none() {
+        let label = node
+            .child_by_field_name("label")
+            .or_else(|| node.named_child(0))
+            .and_then(|n| n.utf8_text(source).ok())
+            .map(|s| s.trim().trim_start_matches('\'').to_string())
+            .filter(|s| !s.is_empty())
+            .or_else(|| {
                 let mut c = node.walk();
                 for ch in node.children(&mut c) {
-                    if ch.kind() == "label_name" {
-                        found = ch.utf8_text(source).ok().map(|s| s.trim().to_string());
-                        break;
+                    if matches!(
+                        ch.kind(),
+                        "label_name" | "label" | "statement_identifier" | "identifier"
+                    ) {
+                        return ch.utf8_text(source).ok().map(|s| {
+                            s.trim().trim_start_matches('\'').to_string()
+                        });
                     }
                 }
-            }
-            found.unwrap_or_default()
-        };
+                None
+            })
+            .unwrap_or_default();
         if !label.is_empty() {
             let target = self.ensure_label_block(&label);
             self.cfg
@@ -1294,13 +1427,18 @@ impl<'a> CfgBuilder<'a> {
             .child_by_field_name("label")
             .or_else(|| {
                 // Java: `identifier ':' statement` (no label field).
+                // C: `statement_identifier` is usually the `label` field already.
                 node.named_child(0).filter(|n| {
-                    matches!(n.kind(), "identifier" | "label_name")
+                    matches!(
+                        n.kind(),
+                        "identifier" | "label_name" | "statement_identifier" | "label"
+                    )
                 })
             })
             .and_then(|n| n.utf8_text(source).ok())
             .unwrap_or("")
             .trim()
+            .trim_start_matches('\'')
             .to_string();
         if label.is_empty() {
             return Ok(());
@@ -1318,7 +1456,7 @@ impl<'a> CfgBuilder<'a> {
             if !child.is_named() {
                 continue;
             }
-            if child.kind() == "label_name" {
+            if child.kind() == "label_name" || child.kind() == "statement_identifier" {
                 continue;
             }
             if node.child_by_field_name("label").is_some_and(|l| l.id() == child.id()) {
@@ -1327,7 +1465,7 @@ impl<'a> CfgBuilder<'a> {
             // Java label identifier is the first named child — skip it.
             if child.kind() == "identifier" {
                 if let Ok(t) = child.utf8_text(source) {
-                    if t.trim() == label {
+                    if t.trim().trim_start_matches('\'') == label {
                         continue;
                     }
                 }
@@ -1366,14 +1504,19 @@ impl<'a> CfgBuilder<'a> {
         true_dest: BlockId,
         false_dest: BlockId,
     ) -> Result<()> {
-        // Unwrap Java/C-style `(expr)`.
+        // Unwrap Java/C-style `(expr)` and C++ `condition_clause`.
         let cond = {
             let mut c = cond;
-            while c.kind() == "parenthesized_expression" {
-                if let Some(inner) = c.named_child(0) {
-                    c = inner;
-                } else {
-                    break;
+            loop {
+                match c.kind() {
+                    "parenthesized_expression" | "condition_clause" => {
+                        if let Some(inner) = c.named_child(0) {
+                            c = inner;
+                        } else {
+                            break;
+                        }
+                    }
+                    _ => break,
                 }
             }
             c
@@ -1442,10 +1585,24 @@ impl<'a> CfgBuilder<'a> {
             defined_vars: HashSet::new(),
             used_vars: HashSet::new(),
         });
+        self.note_setjmp_in_expr(cond, source);
         let from = self.current_block;
         self.cfg.add_edge(from, true_dest, CfgEdgeType::IfTrue);
         self.cfg.add_edge(from, false_dest, CfgEdgeType::IfFalse);
         Ok(())
+    }
+
+    fn note_setjmp_in_expr(&mut self, node: Node, source: &[u8]) {
+        if is_setjmp_call(node, source) {
+            self.setjmp_sites.push(self.current_block);
+            return;
+        }
+        let mut c = node.walk();
+        for ch in node.children(&mut c) {
+            if ch.is_named() {
+                self.note_setjmp_in_expr(ch, source);
+            }
+        }
     }
 
     fn visit_match(&mut self, node: Node, source: &[u8]) -> Result<()> {
@@ -1608,8 +1765,11 @@ impl<'a> CfgBuilder<'a> {
         let mut fallthrough_from: Option<BlockId> = None;
         let prev_implicit = self.switch_implicit_fallthrough;
         for case in &cases {
-            // Java classic groups fall through by default; arrow rules / Go cases do not.
-            self.switch_implicit_fallthrough = matches!(case.kind(), "switch_block_statement_group");
+            // Java classic groups and C `case_statement` fall through by default.
+            self.switch_implicit_fallthrough = matches!(
+                case.kind(),
+                "switch_block_statement_group" | "case_statement" | "default_statement"
+            );
             let is_default = is_switch_default_case(*case, source);
             if is_default {
                 has_default = true;
@@ -1669,7 +1829,7 @@ impl<'a> CfgBuilder<'a> {
             return Ok(());
         }
         match case.kind() {
-            "switch_block_statement_group" => {
+            "switch_block_statement_group" | "switch_rule" => {
                 let mut c = case.walk();
                 for child in case.children(&mut c) {
                     if !child.is_named() {
@@ -1682,13 +1842,15 @@ impl<'a> CfgBuilder<'a> {
                     self.visit_statement(child, source)?;
                 }
             }
-            "switch_rule" => {
+            "case_statement" | "default_statement" => {
+                // C/C++: `case 1: stmt; break;` — statements are direct children.
+                let value = case.child_by_field_name("value");
                 let mut c = case.walk();
                 for child in case.children(&mut c) {
                     if !child.is_named() {
                         continue;
                     }
-                    if child.kind() == "switch_label" {
+                    if value.is_some_and(|v| v.id() == child.id()) {
                         continue;
                     }
                     self.visit_statement(child, source)?;
@@ -1922,6 +2084,14 @@ fn is_switch_default_case(case: Node, source: &[u8]) -> bool {
     ) {
         return true;
     }
+    // C/C++: `default:` is a `case_statement` with no `value` field.
+    if case.kind() == "case_statement" && case.child_by_field_name("value").is_none() {
+        if let Ok(t) = case.utf8_text(source) {
+            if t.trim().starts_with("default") {
+                return true;
+            }
+        }
+    }
     let mut c = case.walk();
     for child in case.children(&mut c) {
         if child.kind() == "switch_label" {
@@ -2030,6 +2200,32 @@ fn is_diverging_macro(node: Node, source: &[u8]) -> bool {
         name,
         "panic" | "todo" | "unimplemented" | "unreachable"
     )
+}
+
+fn call_callee_name<'a>(node: Node<'a>, source: &'a [u8]) -> Option<&'a str> {
+    let call = if node.kind() == "call_expression" {
+        node
+    } else {
+        return None;
+    };
+    call.child_by_field_name("function")
+        .or_else(|| call.named_child(0))
+        .and_then(|f| f.utf8_text(source).ok())
+        .map(|s| s.trim())
+}
+
+fn is_terminating_call(node: Node, source: &[u8]) -> bool {
+    call_callee_name(node, source).is_some_and(|s| {
+        matches!(s, "abort" | "exit" | "_Exit" | "quick_exit")
+    })
+}
+
+fn is_setjmp_call(node: Node, source: &[u8]) -> bool {
+    call_callee_name(node, source).is_some_and(|s| matches!(s, "setjmp" | "_setjmp" | "sigsetjmp"))
+}
+
+fn is_longjmp_call(node: Node, source: &[u8]) -> bool {
+    call_callee_name(node, source).is_some_and(|s| matches!(s, "longjmp" | "_longjmp" | "siglongjmp"))
 }
 
 fn logical_operator<'a>(node: Node<'a>, source: &'a [u8]) -> Option<&'a str> {
@@ -3094,6 +3290,10 @@ int abs_val(int x) {
 "#;
         let cfg = build_cfg_for_function("c", code, "abs_val").unwrap();
         assert!(cfg.blocks.len() >= 4);
+        assert!(cfg
+            .edges
+            .iter()
+            .any(|e| e.edge_type == CfgEdgeType::IfTrue));
     }
 
     #[test]
@@ -3124,6 +3324,343 @@ int classify(int x) {
 "#;
         let cfg = build_cfg_for_function("c", code, "classify").unwrap();
         assert!(cfg.blocks.len() >= 4);
+    }
+
+    fn c_texts(cfg: &ControlFlowGraph) -> Vec<String> {
+        cfg.blocks
+            .values()
+            .flat_map(|b| b.statements.iter().map(|s| s.text.clone()))
+            .collect()
+    }
+
+    fn c_kinds(cfg: &ControlFlowGraph) -> Vec<StatementKind> {
+        cfg.blocks
+            .values()
+            .flat_map(|b| b.statements.iter().map(|s| s.kind))
+            .collect()
+    }
+
+    fn c_block_ids(cfg: &ControlFlowGraph, needle: &str) -> Vec<uuid::Uuid> {
+        cfg.blocks
+            .values()
+            .filter(|b| b.statements.iter().any(|s| s.text.contains(needle)))
+            .map(|b| b.id)
+            .collect()
+    }
+
+    #[test]
+    fn test_c_short_circuit_and() {
+        let code = r#"
+int sc(int a, int b) {
+    if (a && b) {
+        return 1;
+    }
+    return 0;
+}
+"#;
+        let cfg = build_cfg_for_function("c", code, "sc").unwrap();
+        let texts = c_texts(&cfg);
+        assert!(
+            texts.iter().any(|t| t.trim() == "a"),
+            "&& left must split, got {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t.trim() == "b"),
+            "&& right must split, got {texts:?}"
+        );
+        assert!(
+            !texts.iter().any(|t| t.contains("a && b")),
+            "must not keep (a && b) as one blob, got {texts:?}"
+        );
+    }
+
+    #[test]
+    fn test_c_for_init_cond_update_continue() {
+        let code = r#"
+int sum(int n) {
+    int total = 0;
+    for (int i = 0; i < n; i++) {
+        if (i == 1) {
+            continue;
+        }
+        total += i;
+    }
+    return total;
+}
+"#;
+        let cfg = build_cfg_for_function("c", code, "sum").unwrap();
+        let texts = c_texts(&cfg);
+        assert!(
+            texts.iter().any(|t| t.contains("i = 0") || t.contains("i=0")),
+            "for init, got {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t.contains("i < n") || t.contains("i<n")),
+            "for condition, got {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|t| t.contains("i++")),
+            "for update, got {texts:?}"
+        );
+        assert!(cfg.has_cycle());
+        let cont = c_block_ids(&cfg, "continue");
+        let updates = c_block_ids(&cfg, "i++");
+        assert!(
+            cont.iter().any(|c| {
+                cfg.edges.iter().any(|e| {
+                    e.from == *c && updates.contains(&e.to) && e.edge_type == CfgEdgeType::Jump
+                })
+            }),
+            "continue must Jump to i++"
+        );
+    }
+
+    #[test]
+    fn test_c_do_while_cycle() {
+        let code = r#"
+int dw(int n) {
+    int i = 0;
+    do {
+        i++;
+    } while (i < n);
+    return i;
+}
+"#;
+        let cfg = build_cfg_for_function("c", code, "dw").unwrap();
+        assert!(cfg.has_cycle(), "do-while must cycle");
+        assert!(
+            c_texts(&cfg).iter().any(|t| t.contains("i++")),
+            "body must lower"
+        );
+        assert!(
+            c_texts(&cfg)
+                .iter()
+                .any(|t| t.contains("i < n") || t.contains("i<n")),
+            "condition must be on header, got {:?}",
+            c_texts(&cfg)
+        );
+    }
+
+    #[test]
+    fn test_c_switch_fallthrough_and_returns() {
+        let code = r#"
+int sw(int x) {
+    int y = 0;
+    switch (x) {
+        case 1:
+            y = 10;
+        case 2:
+            y = 20;
+            break;
+        default:
+            return 0;
+    }
+    return y;
+}
+"#;
+        let cfg = build_cfg_for_function("c", code, "sw").unwrap();
+        assert!(
+            !c_texts(&cfg)
+                .iter()
+                .any(|t| t.trim_start().starts_with("switch")),
+            "switch must not be opaque, got {:?}",
+            c_texts(&cfg)
+        );
+        assert!(
+            c_texts(&cfg).iter().any(|t| t.contains("y = 10") || t.contains("y=10")),
+            "case 1 body must lower, got {:?}",
+            c_texts(&cfg)
+        );
+        assert!(
+            c_texts(&cfg).iter().any(|t| t.contains("y = 20") || t.contains("y=20")),
+            "case 2 body must lower, got {:?}",
+            c_texts(&cfg)
+        );
+        let c1 = c_block_ids(&cfg, "y = 10");
+        let c1b = c_block_ids(&cfg, "y=10");
+        let froms: Vec<_> = c1.into_iter().chain(c1b).collect();
+        let c2 = c_block_ids(&cfg, "y = 20");
+        let c2b = c_block_ids(&cfg, "y=20");
+        let tos: Vec<_> = c2.into_iter().chain(c2b).collect();
+        assert!(
+            froms.iter().any(|f| {
+                tos.iter().any(|t| {
+                    cfg.edges.iter().any(|e| {
+                        e.from == *f && e.to == *t && e.edge_type == CfgEdgeType::Jump
+                    })
+                })
+            }),
+            "case 1 must fall through (Jump) into case 2"
+        );
+        assert!(
+            c_kinds(&cfg)
+                .iter()
+                .any(|k| *k == StatementKind::Return),
+            "default return must lower"
+        );
+    }
+
+    #[test]
+    fn test_c_goto_and_label() {
+        let code = r#"
+int g(int x) {
+    if (x < 0) {
+        goto done;
+    }
+    x = x + 1;
+done:
+    return x;
+}
+"#;
+        let cfg = build_cfg_for_function("c", code, "g").unwrap();
+        assert!(
+            c_texts(&cfg).iter().any(|t| t.contains("goto done")),
+            "goto must appear, got {:?}",
+            c_texts(&cfg)
+        );
+        let froms = c_block_ids(&cfg, "goto done");
+        let rets = c_block_ids(&cfg, "return x");
+        assert!(!froms.is_empty() && !rets.is_empty());
+        assert!(
+            froms.iter().any(|f| {
+                rets.iter().any(|r| {
+                    cfg.edges.iter().any(|e| e.from == *f && e.to == *r)
+                        || {
+                            use std::collections::{HashSet, VecDeque};
+                            let mut seen = HashSet::new();
+                            let mut q = VecDeque::from([*f]);
+                            while let Some(n) = q.pop_front() {
+                                if n == *r {
+                                    return true;
+                                }
+                                if !seen.insert(n) {
+                                    continue;
+                                }
+                                for e in &cfg.edges {
+                                    if e.from == n {
+                                        q.push_back(e.to);
+                                    }
+                                }
+                            }
+                            false
+                        }
+                })
+            }),
+            "goto done must reach labeled return"
+        );
+        // Unreachable assignment after goto should not be required on the goto path.
+        assert!(
+            cfg.edges
+                .iter()
+                .any(|e| froms.contains(&e.from) && e.edge_type == CfgEdgeType::Jump),
+            "goto must Jump"
+        );
+    }
+
+    #[test]
+    fn test_c_ternary_branches() {
+        let code = r#"
+int t(int y) {
+    return y ? y : -1;
+}
+"#;
+        let cfg = build_cfg_for_function("c", code, "t").unwrap();
+        assert!(
+            cfg.edges
+                .iter()
+                .any(|e| e.edge_type == CfgEdgeType::IfTrue)
+                && cfg
+                    .edges
+                    .iter()
+                    .any(|e| e.edge_type == CfgEdgeType::IfFalse),
+            "ternary must split"
+        );
+        // Condition should be its own branch text (not only the whole ternary as one stmt).
+        assert!(
+            c_texts(&cfg).iter().any(|t| t.trim() == "y"),
+            "ternary condition must lower, got {:?}",
+            c_texts(&cfg)
+        );
+    }
+
+    #[test]
+    fn test_c_abort_and_exit_terminate() {
+        let code = r#"
+void boom(void) {
+    abort();
+}
+"#;
+        let cfg = build_cfg_for_function("c", code, "boom").unwrap();
+        assert!(
+            c_texts(&cfg).iter().any(|t| t.contains("abort")),
+            "abort must appear"
+        );
+        assert!(
+            cfg.edges.iter().any(|e| {
+                matches!(
+                    e.edge_type,
+                    CfgEdgeType::Exception | CfgEdgeType::Return | CfgEdgeType::Jump
+                )
+            }),
+            "abort must terminate"
+        );
+
+        let code2 = r#"
+void bye(void) {
+    exit(1);
+}
+"#;
+        let cfg2 = build_cfg_for_function("c", code2, "bye").unwrap();
+        assert!(
+            cfg2.edges.iter().any(|e| {
+                matches!(
+                    e.edge_type,
+                    CfgEdgeType::Exception | CfgEdgeType::Return | CfgEdgeType::Jump
+                )
+            }),
+            "exit must terminate"
+        );
+    }
+
+    #[test]
+    fn test_c_setjmp_longjmp_approx() {
+        let code = r#"
+int sj(void) {
+    if (setjmp(buf) == 0) {
+        longjmp(buf, 1);
+    }
+    return 1;
+}
+"#;
+        let cfg = build_cfg_for_function("c", code, "sj").unwrap();
+        assert!(
+            c_texts(&cfg).iter().any(|t| t.contains("setjmp")),
+            "setjmp must appear, got {:?}",
+            c_texts(&cfg)
+        );
+        assert!(
+            c_texts(&cfg).iter().any(|t| t.contains("longjmp")),
+            "longjmp must appear, got {:?}",
+            c_texts(&cfg)
+        );
+        let sj = c_block_ids(&cfg, "setjmp");
+        let lj = c_block_ids(&cfg, "longjmp");
+        assert!(!sj.is_empty() && !lj.is_empty());
+        assert!(
+            lj.iter().any(|l| {
+                sj.iter().any(|s| {
+                    cfg.edges.iter().any(|e| {
+                        e.from == *l
+                            && e.to == *s
+                            && matches!(
+                                e.edge_type,
+                                CfgEdgeType::Jump | CfgEdgeType::Exception
+                            )
+                    })
+                })
+            }),
+            "longjmp must edge back to a setjmp site"
+        );
     }
 
     #[test]

--- a/crates/rbuilder-analysis/src/cfg_builder.rs
+++ b/crates/rbuilder-analysis/src/cfg_builder.rs
@@ -396,6 +396,11 @@ impl<'a> CfgBuilder<'a> {
                     }
                     return Ok(());
                 }
+                // Lower await / ?? /?. inside initializers before recording the decl.
+                self.visit_declaration_initializers(node, source)?;
+                if !self.flow_active {
+                    return Ok(());
+                }
                 self.add_statement(node, source, StatementKind::Declaration)?;
                 Ok(())
             }
@@ -1722,15 +1727,60 @@ impl<'a> CfgBuilder<'a> {
         Ok(())
     }
 
-    /// C# `using var r = ...;` — Dispose at end of enclosing block / on return.
+    /// Walk declarator initializers for nested control-flow (`await`, `??`, `?.`, …).
+    fn visit_declaration_initializers(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        let mut stack = vec![node];
+        while let Some(n) = stack.pop() {
+            if n.kind() == "variable_declarator" {
+                if let Some(value) = n.child_by_field_name("value") {
+                    self.visit_expr_for_control_flow(value, source)?;
+                } else {
+                    // C#: initializer is an unfielded named child after `name`.
+                    let name = n.child_by_field_name("name");
+                    let mut c = n.walk();
+                    for ch in n.children(&mut c) {
+                        if !ch.is_named() {
+                            continue;
+                        }
+                        if name.is_some_and(|nm| nm.id() == ch.id()) {
+                            continue;
+                        }
+                        self.visit_expr_for_control_flow(ch, source)?;
+                        if !self.flow_active {
+                            return Ok(());
+                        }
+                    }
+                }
+                if !self.flow_active {
+                    return Ok(());
+                }
+                continue;
+            }
+            let mut c = n.walk();
+            for ch in n.children(&mut c) {
+                if ch.is_named() {
+                    stack.push(ch);
+                }
+            }
+        }
+        Ok(())
+    }
+
     fn visit_using_declaration(&mut self, node: Node, source: &[u8]) -> Result<()> {
+        self.visit_declaration_initializers(node, source)?;
+        if !self.flow_active {
+            return Ok(());
+        }
         self.add_statement(node, source, StatementKind::Declaration)?;
         let mut resource_name = "resource".to_string();
         let line = node.start_position().row + 1;
         if let Some(decl) = find_child_kind(node, "variable_declaration")
             .or_else(|| find_child_kind(node, "variable_declarator"))
         {
-            if let Some(id) = find_child_kind(decl, "identifier") {
+            if let Some(id) = decl
+                .child_by_field_name("name")
+                .or_else(|| find_child_kind(decl, "identifier"))
+            {
                 if let Ok(t) = id.utf8_text(source) {
                     resource_name = t.trim().to_string();
                 }
@@ -4945,6 +4995,34 @@ public class Demo {
                 })
             }),
             "await must split resume (IfTrue) vs suspend (IfFalse/Return)"
+        );
+    }
+
+    #[test]
+    fn test_csharp_await_in_var_declaration() {
+        let code = r#"
+public class Demo {
+    public async System.Threading.Tasks.Task<int> Aw() {
+        var t = await System.Threading.Tasks.Task.FromResult(1);
+        return t;
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("csharp", code, "Aw").unwrap();
+        assert!(
+            cs_texts(&cfg).iter().any(|t| t.contains("await")),
+            "await in var init must appear, got {:?}",
+            cs_texts(&cfg)
+        );
+        assert!(
+            cfg.edges
+                .iter()
+                .any(|e| e.edge_type == CfgEdgeType::IfTrue)
+                && cfg
+                    .edges
+                    .iter()
+                    .any(|e| e.edge_type == CfgEdgeType::IfFalse),
+            "var await must suspend/resume split"
         );
     }
 

--- a/crates/rbuilder-analysis/src/def_use.rs
+++ b/crates/rbuilder-analysis/src/def_use.rs
@@ -67,6 +67,42 @@ fn collect_assignment_lhs(left: Node, source: &[u8], defined: &mut HashSet<Strin
     }
 }
 
+/// Go `var_spec`: `name` / `name_list` + optional `value` / `value_list`.
+fn collect_go_var_spec(
+    spec: Node,
+    source: &[u8],
+    defined: &mut HashSet<String>,
+    used: &mut HashSet<String>,
+) {
+    if let Some(name) = spec.child_by_field_name("name") {
+        collect_pattern_defs(name, source, defined);
+    }
+    let mut cursor = spec.walk();
+    for child in spec.children(&mut cursor) {
+        match child.kind() {
+            "identifier" => {
+                collect_pattern_defs(child, source, defined);
+            }
+            "expression_list" => {
+                // Could be names or values — tree-sitter-go uses name field when present.
+                if spec.child_by_field_name("name").is_none()
+                    && spec.child_by_field_name("value").is_none()
+                {
+                    // Fallback: first expression_list is often names in older grammars
+                }
+                collect_def_use(child, source, defined, used, false);
+            }
+            _ => {}
+        }
+    }
+    if let Some(value) = spec
+        .child_by_field_name("value")
+        .or_else(|| spec.child_by_field_name("right"))
+    {
+        collect_def_use(value, source, defined, used, false);
+    }
+}
+
 fn collect_def_use(
     node: Node,
     source: &[u8],
@@ -140,12 +176,30 @@ fn collect_def_use(
         }
 
         // Go
-        "short_var_declaration" | "var_declaration" | "assignment_statement" => {
+        "short_var_declaration" | "assignment_statement" => {
             if let Some(left) = node.child_by_field_name("left") {
                 collect_assignment_lhs(left, source, defined, used);
             }
             if let Some(right) = node.child_by_field_name("right") {
                 collect_def_use(right, source, defined, used, false);
+            }
+        }
+        // `var` / `var ( ... )` — children are var_spec / var_spec_list (no left/right fields).
+        "var_declaration" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                match child.kind() {
+                    "var_spec" => collect_go_var_spec(child, source, defined, used),
+                    "var_spec_list" => {
+                        let mut c2 = child.walk();
+                        for spec in child.children(&mut c2) {
+                            if spec.kind() == "var_spec" {
+                                collect_go_var_spec(spec, source, defined, used);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
             }
         }
         "range_clause" => {

--- a/crates/rbuilder-analysis/src/field_write.rs
+++ b/crates/rbuilder-analysis/src/field_write.rs
@@ -5,13 +5,16 @@
 //! from function parameters + language-specific locals.
 
 use crate::cfg::ControlFlowGraph;
-use crate::cfg_pdg_archive::CfgPdgArchive;
+use crate::cfg_pdg_archive::{CfgPdgArchive, CfgPdgRecord};
+use crate::field_write_locals::LocalsParseContext;
 use rbuilder_error::{Error, Result};
 use rbuilder_graph::schema::Node;
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use uuid::Uuid;
 
 /// On-disk filename under `.rbuilder/analysis/`.
@@ -89,6 +92,9 @@ impl FieldWriteIndex {
     }
 
     /// Build from a CFG/PDG archive and L_repo function nodes.
+    ///
+    /// Groups work by source file so each file is loaded and parsed once, then
+    /// processes files in parallel with Rayon.
     pub fn build_from_archive(
         archive: &CfgPdgArchive,
         functions: &[Node],
@@ -96,7 +102,8 @@ impl FieldWriteIndex {
         repo_root: Option<&Path>,
     ) -> Self {
         let by_id: HashMap<Uuid, &Node> = functions.iter().map(|n| (n.id, n)).collect();
-        let mut writes = Vec::new();
+
+        let mut by_file: HashMap<String, Vec<&CfgPdgRecord>> = HashMap::new();
         for record in archive.records.values() {
             let func = by_id.get(&record.function_id).copied();
             let file = record
@@ -104,35 +111,68 @@ impl FieldWriteIndex {
                 .clone()
                 .or_else(|| func.and_then(|n| n.file_path.clone()))
                 .unwrap_or_default();
-            let function_name = if record.function_name.is_empty() {
-                func.map(|n| n.name.clone())
-                    .unwrap_or_else(|| "unknown".into())
-            } else {
-                record.function_name.clone()
-            };
-            let is_constructor = func.map(is_constructor_node).unwrap_or(false)
-                || function_name_looks_like_ctor(&function_name, func);
-            let mut type_env = type_env_from_node(func);
-            if let Some(node) = func {
-                if let Some(enclosing) = enclosing_type_name(node) {
-                    type_env.insert("this".into(), enclosing.clone());
-                    type_env.insert("self".into(), enclosing);
-                }
-            }
-            if let Some(src) = load_source(&file, repo_root) {
-                let lang = language_from_path(&file);
-                merge_local_types(&lang, &src, &function_name, &mut type_env);
-            }
-            extract_writes_from_cfg(
-                &record.cfg,
-                record.function_id,
-                &function_name,
-                is_constructor,
-                &file,
-                &type_env,
-                &mut writes,
-            );
+            by_file.entry(file).or_default().push(record);
         }
+
+        let repo_root = repo_root.map(Path::to_path_buf);
+        let mut writes: Vec<FieldWrite> = by_file
+            .into_par_iter()
+            .flat_map(|(file, records)| {
+                let source = if file.is_empty() {
+                    None
+                } else {
+                    load_source(&file, repo_root.as_deref()).map(Arc::new)
+                };
+                let lang = language_from_path(&file);
+                let locals_ctx = source
+                    .as_ref()
+                    .and_then(|src| LocalsParseContext::try_new(&lang, src.as_str()));
+
+                let mut file_writes = Vec::new();
+                for record in records {
+                    let func = by_id.get(&record.function_id).copied();
+                    let function_name = if record.function_name.is_empty() {
+                        func.map(|n| n.name.clone())
+                            .unwrap_or_else(|| "unknown".into())
+                    } else {
+                        record.function_name.clone()
+                    };
+                    let is_constructor = func.map(is_constructor_node).unwrap_or(false)
+                        || function_name_looks_like_ctor(&function_name, func);
+                    let mut type_env = type_env_from_node(func);
+                    if let Some(node) = func {
+                        if let Some(enclosing) = enclosing_type_name(node) {
+                            type_env.insert("this".into(), enclosing.clone());
+                            type_env.insert("self".into(), enclosing);
+                        }
+                    }
+                    if let Some(ctx) = &locals_ctx {
+                        ctx.merge_into(&function_name, &mut type_env);
+                    }
+                    extract_writes_from_cfg(
+                        &record.cfg,
+                        record.function_id,
+                        &function_name,
+                        is_constructor,
+                        &file,
+                        &type_env,
+                        &mut file_writes,
+                    );
+                }
+                file_writes
+            })
+            .collect();
+
+        writes.sort_by(|a, b| {
+            (&a.file, a.line, &a.function_id, &a.member, &a.code_snippet).cmp(&(
+                &b.file,
+                b.line,
+                &b.function_id,
+                &b.member,
+                &b.code_snippet,
+            ))
+        });
+
         Self {
             version: FIELD_WRITE_INDEX_VERSION,
             graph_digest,
@@ -324,15 +364,6 @@ fn language_from_path(path: &str) -> String {
         })
         .unwrap_or("unknown")
         .to_string()
-}
-
-fn merge_local_types(
-    language: &str,
-    source: &str,
-    function_name: &str,
-    env: &mut HashMap<String, String>,
-) {
-    crate::field_write_locals::merge_local_types(language, source, function_name, env);
 }
 
 fn extract_writes_from_cfg(
@@ -592,6 +623,83 @@ public class OrderProcessor {
         assert_eq!(hits.len(), 1, "hits={hits:?}");
         assert!(hits[0].code_snippet.contains("order.status"));
         assert!(!hits[0].is_constructor);
+    }
+
+    #[test]
+    fn same_file_two_functions_parse_once_resolves_locals() {
+        use crate::cfg_builder::build_cfg_for_function;
+        use crate::cfg_pdg_archive::{CfgPdgArchive, CfgPdgRecord};
+        use crate::pdg::ProgramDependenceGraph;
+        use rbuilder_graph::schema::{Node, NodeType};
+        use std::sync::Arc;
+        use tempfile::TempDir;
+
+        let source = r#"
+public class Dual {
+    public void first(OrderDTO a) {
+        OrderDTO x = a;
+        x.status = "A";
+    }
+    public void second(OrderDTO b) {
+        OrderDTO y = b;
+        y.status = "B";
+    }
+}
+"#;
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("Dual.java");
+        std::fs::write(&path, source).unwrap();
+        let file = path.to_string_lossy().to_string();
+
+        let cfg_first = build_cfg_for_function("java", source, "first").expect("first cfg");
+        let cfg_second = build_cfg_for_function("java", source, "second").expect("second cfg");
+
+        let mut first_fn = Node::new(NodeType::Function, "first".into());
+        first_fn.file_path = Some(file.clone());
+        let mut second_fn = Node::new(NodeType::Function, "second".into());
+        second_fn.file_path = Some(file.clone());
+
+        let id_first = first_fn.id;
+        let id_second = second_fn.id;
+        let pdg_first = ProgramDependenceGraph::build(&cfg_first, source.as_bytes()).unwrap();
+        let pdg_second = ProgramDependenceGraph::build(&cfg_second, source.as_bytes()).unwrap();
+
+        let mut archive = CfgPdgArchive::default();
+        archive.insert(CfgPdgRecord {
+            function_id: id_first,
+            code_hash: "1".into(),
+            function_name: "first".into(),
+            file_path: Some(file.clone()),
+            cfg: cfg_first,
+            pdg: Arc::new(pdg_first),
+        });
+        archive.insert(CfgPdgRecord {
+            function_id: id_second,
+            code_hash: "2".into(),
+            function_name: "second".into(),
+            file_path: Some(file.clone()),
+            cfg: cfg_second,
+            pdg: Arc::new(pdg_second),
+        });
+
+        let index = FieldWriteIndex::build_from_archive(
+            &archive,
+            &[first_fn, second_fn],
+            None,
+            Some(dir.path()),
+        );
+        let hits = index.query(&MutationQuery {
+            type_name: "OrderDTO".into(),
+            exclude_ctors: false,
+            member: Some("status".into()),
+            include_unresolved: false,
+        });
+        assert_eq!(hits.len(), 2, "hits={hits:?}");
+        assert!(hits.iter().any(|h| h.function_name == "first"));
+        assert!(hits.iter().any(|h| h.function_name == "second"));
+        assert!(hits.iter().all(|h| h.receiver_type.as_deref() == Some("OrderDTO")));
+        // Stable sort: same file, earlier line first
+        assert!(hits[0].line <= hits[1].line);
     }
 
     #[test]

--- a/crates/rbuilder-analysis/src/field_write_locals.rs
+++ b/crates/rbuilder-analysis/src/field_write_locals.rs
@@ -4,7 +4,62 @@
 //! target function. No full type inference / reflection.
 
 use std::collections::HashMap;
-use tree_sitter::{Node, Parser};
+use tree_sitter::{Node, Parser, Tree};
+
+type VisitFn = fn(Node, &[u8], &str, &mut HashMap<String, String>, bool);
+
+/// Pre-parsed source for merging locals across many functions in one file.
+///
+/// Tree-sitter [`Tree`] is not shared across threads; keep one context per Rayon task.
+pub struct LocalsParseContext<'a> {
+    source: &'a str,
+    tree: Tree,
+    visit: VisitFn,
+}
+
+impl<'a> LocalsParseContext<'a> {
+    /// Parse `source` once for `language`. Returns `None` for unknown languages or parse failure.
+    pub fn try_new(language: &str, source: &'a str) -> Option<Self> {
+        let (ts_lang, visit) = language_visit(language)?;
+        let mut parser = Parser::new();
+        parser.set_language(&ts_lang).ok()?;
+        let tree = parser.parse(source, None)?;
+        Some(Self {
+            source,
+            tree,
+            visit,
+        })
+    }
+
+    /// Merge typed locals + formals for `function_name` into `env` using the cached tree.
+    pub fn merge_into(&self, function_name: &str, env: &mut HashMap<String, String>) {
+        (self.visit)(
+            self.tree.root_node(),
+            self.source.as_bytes(),
+            function_name,
+            env,
+            false,
+        );
+    }
+}
+
+fn language_visit(language: &str) -> Option<(tree_sitter::Language, VisitFn)> {
+    Some(match language {
+        "java" => (tree_sitter_java::LANGUAGE.into(), visit_java),
+        "csharp" => (tree_sitter_c_sharp::LANGUAGE.into(), visit_csharp),
+        "go" => (tree_sitter_go::LANGUAGE.into(), visit_go),
+        "rust" => (tree_sitter_rust::LANGUAGE.into(), visit_rust),
+        "python" => (tree_sitter_python::LANGUAGE.into(), visit_python),
+        "javascript" => (tree_sitter_javascript::LANGUAGE.into(), visit_javascript),
+        "typescript" => (
+            tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+            visit_typescript,
+        ),
+        "c" => (tree_sitter_c::LANGUAGE.into(), visit_c_family),
+        "cpp" => (tree_sitter_cpp::LANGUAGE.into(), visit_c_family),
+        _ => return None,
+    })
+}
 
 /// Merge typed locals + formals for `function_name` into `env` (name → bare type).
 pub fn merge_local_types(
@@ -13,86 +68,9 @@ pub fn merge_local_types(
     function_name: &str,
     env: &mut HashMap<String, String>,
 ) {
-    match language {
-        "java" => merge_with_grammar(
-            &tree_sitter_java::LANGUAGE.into(),
-            source,
-            function_name,
-            env,
-            visit_java,
-        ),
-        "csharp" => merge_with_grammar(
-            &tree_sitter_c_sharp::LANGUAGE.into(),
-            source,
-            function_name,
-            env,
-            visit_csharp,
-        ),
-        "go" => merge_with_grammar(
-            &tree_sitter_go::LANGUAGE.into(),
-            source,
-            function_name,
-            env,
-            visit_go,
-        ),
-        "rust" => merge_with_grammar(
-            &tree_sitter_rust::LANGUAGE.into(),
-            source,
-            function_name,
-            env,
-            visit_rust,
-        ),
-        "python" => merge_with_grammar(
-            &tree_sitter_python::LANGUAGE.into(),
-            source,
-            function_name,
-            env,
-            visit_python,
-        ),
-        "javascript" => merge_with_grammar(
-            &tree_sitter_javascript::LANGUAGE.into(),
-            source,
-            function_name,
-            env,
-            visit_javascript,
-        ),
-        "typescript" => {
-            let lang = tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into();
-            merge_with_grammar(&lang, source, function_name, env, visit_typescript)
-        }
-        "c" => merge_with_grammar(
-            &tree_sitter_c::LANGUAGE.into(),
-            source,
-            function_name,
-            env,
-            visit_c_family,
-        ),
-        "cpp" => merge_with_grammar(
-            &tree_sitter_cpp::LANGUAGE.into(),
-            source,
-            function_name,
-            env,
-            visit_c_family,
-        ),
-        _ => {}
+    if let Some(ctx) = LocalsParseContext::try_new(language, source) {
+        ctx.merge_into(function_name, env);
     }
-}
-
-fn merge_with_grammar(
-    language: &tree_sitter::Language,
-    source: &str,
-    function_name: &str,
-    env: &mut HashMap<String, String>,
-    visit: fn(Node, &[u8], &str, &mut HashMap<String, String>, bool),
-) {
-    let mut parser = Parser::new();
-    if parser.set_language(language).is_err() {
-        return;
-    }
-    let Some(tree) = parser.parse(source, None) else {
-        return;
-    };
-    visit(tree.root_node(), source.as_bytes(), function_name, env, false);
 }
 
 fn normalize_type_name(name: &str) -> String {
@@ -753,5 +731,33 @@ func Process(order *OrderDTO) {
             env.get("order").map(|s| s.contains("OrderDTO")).unwrap_or(false),
             "env={env:?}"
         );
+    }
+
+    #[test]
+    fn parse_once_resolves_two_functions_in_same_file() {
+        let source = r#"
+public class Dual {
+    public void first(OrderDTO a) {
+        OrderDTO x = a;
+        x.status = "A";
+    }
+    public void second(OrderDTO b) {
+        OrderDTO y = b;
+        y.status = "B";
+    }
+}
+"#;
+        let ctx = LocalsParseContext::try_new("java", source).expect("parse");
+        let mut env_first = HashMap::new();
+        ctx.merge_into("first", &mut env_first);
+        assert_eq!(env_first.get("a").map(String::as_str), Some("OrderDTO"));
+        assert_eq!(env_first.get("x").map(String::as_str), Some("OrderDTO"));
+        assert!(env_first.get("y").is_none(), "first must not see second locals");
+
+        let mut env_second = HashMap::new();
+        ctx.merge_into("second", &mut env_second);
+        assert_eq!(env_second.get("b").map(String::as_str), Some("OrderDTO"));
+        assert_eq!(env_second.get("y").map(String::as_str), Some("OrderDTO"));
+        assert!(env_second.get("x").is_none(), "second must not see first locals");
     }
 }

--- a/crates/rbuilder-extraction/src/graph_builder.rs
+++ b/crates/rbuilder-extraction/src/graph_builder.rs
@@ -44,6 +44,8 @@ pub struct GraphBuilder {
     symbols_by_qualified: HashMap<String, Vec<Uuid>>,
     symbols_by_suffix: HashMap<String, Vec<Uuid>>,
     indexes_built: bool,
+    /// `OwnerType.field` → simple field type (for late Go selector resolution; spill-safe).
+    field_type_index: HashMap<String, String>,
 }
 
 #[derive(Debug, Default)]
@@ -310,6 +312,12 @@ impl GraphBuilder {
                 .with_property("owner_qualified_name".to_string(), owner_qn.clone());
             if let Some(ty) = &field.field_type {
                 node = node.with_property("field_type".to_string(), ty.clone());
+                let simple = go_simple_type_from_str(ty);
+                self.field_type_index
+                    .insert(format!("{owner_qn}.{}", field.name), simple.clone());
+                // Also index by bare owner name when owner_qn == struct name.
+                self.field_type_index
+                    .insert(format!("{}.{}", symbol.name, field.name), simple);
             }
             if let Some(vis) = &field.visibility {
                 node = node.with_property("visibility".to_string(), vis.clone());
@@ -415,13 +423,18 @@ impl GraphBuilder {
         let from_id =
             self.resolve_symbol_tracked(&relation.from, &relation.location.file, None, None);
 
-        // Use hints for cross-file resolution (best-effort)
-        // Hints are language plugin's best guess at the qualified name based on local context
+        let (to_type_hint, to_qualified_hint) =
+            self.enrich_go_type_hints(relation);
+
         let to_id = self.resolve_symbol_tracked(
             &relation.to,
             &relation.location.file,
-            relation.to_qualified_hint.as_deref(),
-            relation.to_type_hint.as_deref(),
+            to_qualified_hint
+                .as_deref()
+                .or(relation.to_qualified_hint.as_deref()),
+            to_type_hint
+                .as_deref()
+                .or(relation.to_type_hint.as_deref()),
         );
 
         if let (Some(from), Some(to)) = (from_id, to_id) {
@@ -436,6 +449,58 @@ impl GraphBuilder {
             self.commit_edge(edge);
         }
         Ok(())
+    }
+
+    /// Late-bind Go `recv.field.Method` using field Variable nodes from Pass 1.
+    fn enrich_go_type_hints(
+        &self,
+        relation: &Relation,
+    ) -> (Option<String>, Option<String>) {
+        if relation.to_type_hint.is_some() {
+            return (None, None);
+        }
+        let lang = relation
+            .metadata
+            .get("language")
+            .and_then(|v| v.as_str());
+        if lang != Some("go") {
+            return (None, None);
+        }
+        let Some(recv_ty) = relation
+            .metadata
+            .get("go_recv_type")
+            .and_then(|v| v.as_str())
+        else {
+            return (None, None);
+        };
+        let Some(field) = relation
+            .metadata
+            .get("go_field")
+            .and_then(|v| v.as_str())
+        else {
+            return (None, None);
+        };
+        let callee = relation
+            .metadata
+            .get("go_callee")
+            .and_then(|v| v.as_str())
+            .unwrap_or_else(|| {
+                relation
+                    .to
+                    .split('.')
+                    .next_back()
+                    .unwrap_or(relation.to.as_str())
+            });
+
+        let Some(ty) = self
+            .field_type_index
+            .get(&format!("{recv_ty}.{field}"))
+            .cloned()
+        else {
+            return (None, None);
+        };
+        let qh = format!("{ty}.{callee}");
+        (Some(ty), Some(qh))
     }
 
     /// Link code to a configuration key or environment variable usage.
@@ -859,6 +924,14 @@ fn relation_type_to_edge_type(relation_type: RelationType) -> EdgeType {
         RelationType::RequiresResource => EdgeType::RequiresResource,
         RelationType::UsesFact => EdgeType::UsesFact,
     }
+}
+
+fn go_simple_type_from_str(ty: &str) -> String {
+    ty.trim_start_matches('*')
+        .rsplit(['.', '/'])
+        .next()
+        .unwrap_or(ty)
+        .to_string()
 }
 
 #[cfg(test)]

--- a/crates/rbuilder-lang-go/src/plugin.rs
+++ b/crates/rbuilder-lang-go/src/plugin.rs
@@ -18,44 +18,47 @@ impl GoPlugin {
     }
 
     fn extract_function(&self, node: Node, source: &[u8], file_path: &str) -> Result<Symbol> {
-        let mut cursor = node.walk();
         let mut name = None;
         let mut parameters = Vec::new();
         let mut return_type = None;
-        let mut saw_param_list = false;
+        let mut receiver_name: Option<String> = None;
+        let mut receiver_type: Option<String> = None;
 
-        for child in node.children(&mut cursor) {
-            match child.kind() {
-                "identifier" => {
-                    if name.is_none() {
-                        name = Some(child.utf8_text(source)?.to_string());
-                    }
-                }
-                "field_identifier" => {
-                    // method_declaration name
-                    if name.is_none() {
-                        name = Some(child.utf8_text(source)?.to_string());
-                    }
-                }
-                "parameter_list" => {
-                    // method_declaration: first list is receiver; second is params
-                    if node.kind() == "method_declaration" && !saw_param_list {
-                        saw_param_list = true;
-                        continue;
-                    }
-                    parameters = self.extract_parameters(child, source)?;
-                    saw_param_list = true;
-                }
-                "type_identifier" | "pointer_type" | "slice_type" | "qualified_type" => {
-                    return_type = Some(child.utf8_text(source)?.to_string());
-                }
-                _ => {}
-            }
+        if let Some(name_node) = node.child_by_field_name("name") {
+            name = Some(name_node.utf8_text(source)?.to_string());
         }
 
-        // Prefer result field when present (may wrap pointer_type / type_identifier)
+        if let Some(recv) = node.child_by_field_name("receiver") {
+            let (rn, rt) = self.extract_receiver(recv, source)?;
+            receiver_name = rn;
+            receiver_type = rt;
+        }
+
+        if let Some(params) = node.child_by_field_name("parameters") {
+            parameters = self.extract_parameters(params, source)?;
+        }
+
         if let Some(result) = node.child_by_field_name("result") {
             return_type = Some(result.utf8_text(source)?.to_string());
+        } else {
+            // Fallback walk for older paths / free functions without field names
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                match child.kind() {
+                    "identifier" | "field_identifier" if name.is_none() => {
+                        name = Some(child.utf8_text(source)?.to_string());
+                    }
+                    "parameter_list" if parameters.is_empty() && node.kind() == "function_declaration" => {
+                        parameters = self.extract_parameters(child, source)?;
+                    }
+                    "type_identifier" | "pointer_type" | "slice_type" | "qualified_type"
+                        if return_type.is_none() =>
+                    {
+                        return_type = Some(child.utf8_text(source)?.to_string());
+                    }
+                    _ => {}
+                }
+            }
         }
 
         let name = name.ok_or_else(|| Error::ParseError {
@@ -68,8 +71,21 @@ impl GoPlugin {
             if let Some(type_name) = self.constructor_type_name(&name, return_type.as_deref()) {
                 (
                     Some(format!("{type_name}.<init>")),
-                    serde_json::json!({ "language": "go", "is_constructor": true }),
+                    serde_json::json!({
+                        "language": "go",
+                        "is_constructor": true
+                    }),
                 )
+            } else if let Some(rt) = receiver_type.as_ref() {
+                let bare = rt.trim_start_matches('*').to_string();
+                let mut meta = serde_json::json!({
+                    "language": "go",
+                    "receiver_type": bare,
+                });
+                if let Some(rn) = &receiver_name {
+                    meta["receiver_name"] = serde_json::Value::String(rn.clone());
+                }
+                (Some(format!("{bare}.{name}")), meta)
             } else {
                 (None, serde_json::json!({ "language": "go" }))
             };
@@ -100,6 +116,39 @@ impl GoPlugin {
             documentation: None,
             metadata,
         })
+    }
+
+    fn extract_receiver(
+        &self,
+        recv_list: Node,
+        source: &[u8],
+    ) -> Result<(Option<String>, Option<String>)> {
+        let mut cursor = recv_list.walk();
+        for child in recv_list.children(&mut cursor) {
+            if child.kind() != "parameter_declaration" {
+                continue;
+            }
+            let mut name = None;
+            let mut ty = None;
+            let mut c2 = child.walk();
+            for part in child.children(&mut c2) {
+                match part.kind() {
+                    "identifier" => name = Some(part.utf8_text(source)?.to_string()),
+                    "type_identifier" | "pointer_type" | "qualified_type" => {
+                        ty = Some(part.utf8_text(source)?.to_string());
+                    }
+                    _ => {}
+                }
+            }
+            if let Some(t) = child.child_by_field_name("type") {
+                ty = Some(t.utf8_text(source)?.to_string());
+            }
+            if let Some(n) = child.child_by_field_name("name") {
+                name = Some(n.utf8_text(source)?.to_string());
+            }
+            return Ok((name, ty));
+        }
+        Ok((None, None))
     }
 
     /// `NewXxx` returning `Xxx` or `*Xxx` → treat as constructor for `Xxx`.
@@ -213,19 +262,36 @@ impl GoPlugin {
                 let mut field_cursor = child.walk();
                 for field_child in child.children(&mut field_cursor) {
                     if field_child.kind() == "field_declaration" {
-                        let mut decl_cursor = field_child.walk();
                         let mut name = None;
                         let mut field_type = None;
+                        let mut embedded = false;
 
+                        let mut decl_cursor = field_child.walk();
                         for decl_child in field_child.children(&mut decl_cursor) {
                             match decl_child.kind() {
                                 "field_identifier" => {
                                     name = Some(decl_child.utf8_text(source)?.to_string());
                                 }
-                                "type_identifier" | "pointer_type" | "slice_type" => {
-                                    field_type = Some(decl_child.utf8_text(source)?.to_string());
+                                "type_identifier" | "pointer_type" | "slice_type"
+                                | "qualified_type" | "generic_type" => {
+                                    field_type =
+                                        Some(decl_child.utf8_text(source)?.to_string());
                                 }
                                 _ => {}
+                            }
+                        }
+                        if let Some(t) = field_child.child_by_field_name("type") {
+                            field_type = Some(t.utf8_text(source)?.to_string());
+                        }
+                        if let Some(n) = field_child.child_by_field_name("name") {
+                            name = Some(n.utf8_text(source)?.to_string());
+                        }
+
+                        // Embedded field: no explicit name (LF-06).
+                        if name.is_none() {
+                            if let Some(ty) = &field_type {
+                                name = Some(ty.trim_start_matches('*').to_string());
+                                embedded = true;
                             }
                         }
 
@@ -233,7 +299,11 @@ impl GoPlugin {
                             fields.push(Field {
                                 name,
                                 field_type,
-                                visibility: None, // Go uses capitalization for visibility
+                                visibility: if embedded {
+                                    Some("embedded".into())
+                                } else {
+                                    None
+                                },
                             });
                         }
                     }
@@ -255,6 +325,7 @@ impl GoPlugin {
             }
         }
 
+        // type_spec wraps name + interface_type — walk parent if needed via caller
         let name = name.ok_or_else(|| Error::ParseError {
             file: file_path.into(),
             line: node.start_position().row + 1,
@@ -264,7 +335,7 @@ impl GoPlugin {
         Ok(Symbol {
             name: name.clone(),
             symbol_type: SymbolType::Interface,
-            qualified_name: None,
+            qualified_name: Some(name),
             location: SourceLocation {
                 file: file_path.to_string(),
                 start_line: node.start_position().row + 1,
@@ -278,8 +349,119 @@ impl GoPlugin {
             fields: vec![],
             modifiers: vec![],
             documentation: None,
-            metadata: serde_json::json!({}),
+            metadata: serde_json::json!({ "language": "go" }),
         })
+    }
+
+    /// Interface method elements → Function symbols with `Iface.Method` FQN.
+    /// Also promotes methods from embedded interfaces (LF-04 / CRI RuntimeService pattern).
+    fn extract_interface_methods(
+        &self,
+        interface_type: Node,
+        iface_name: &str,
+        source: &[u8],
+        file_path: &str,
+        prior_symbols: &[Symbol],
+    ) -> Result<Vec<Symbol>> {
+        let mut methods = Vec::new();
+        let mut embedded: Vec<String> = Vec::new();
+        let mut cursor = interface_type.walk();
+        for child in interface_type.children(&mut cursor) {
+            match child.kind() {
+                "method_elem" | "method_spec" => {
+                    let mut name = None;
+                    let mut parameters = Vec::new();
+                    let mut return_type = None;
+                    if let Some(n) = child.child_by_field_name("name") {
+                        name = Some(n.utf8_text(source)?.to_string());
+                    }
+                    if let Some(p) = child.child_by_field_name("parameters") {
+                        parameters = self.extract_parameters(p, source)?;
+                    }
+                    if let Some(r) = child.child_by_field_name("result") {
+                        return_type = Some(r.utf8_text(source)?.to_string());
+                    }
+                    let mut c2 = child.walk();
+                    for part in child.children(&mut c2) {
+                        if name.is_none() && part.kind() == "field_identifier" {
+                            name = Some(part.utf8_text(source)?.to_string());
+                        }
+                        if part.kind() == "parameter_list" && parameters.is_empty() {
+                            parameters = self.extract_parameters(part, source)?;
+                        }
+                    }
+                    let Some(method_name) = name else {
+                        continue;
+                    };
+                    methods.push(Symbol {
+                        name: method_name.clone(),
+                        symbol_type: SymbolType::Function,
+                        qualified_name: Some(format!("{iface_name}.{method_name}")),
+                        location: SourceLocation {
+                            file: file_path.to_string(),
+                            start_line: child.start_position().row + 1,
+                            end_line: child.end_position().row + 1,
+                            start_column: child.start_position().column,
+                            end_column: child.end_position().column,
+                        },
+                        signature: Some(child.utf8_text(source)?.trim().to_string()),
+                        return_type,
+                        parameters,
+                        fields: vec![],
+                        modifiers: vec![],
+                        documentation: None,
+                        metadata: serde_json::json!({
+                            "language": "go",
+                            "interface_method": true,
+                            "receiver_type": iface_name,
+                        }),
+                    });
+                }
+                "type_identifier" | "qualified_type" | "type_elem" => {
+                    // Embedded interface (e.g. RuntimeService embeds PodSandboxManager).
+                    if let Ok(t) = child.utf8_text(source) {
+                        let bare = t
+                            .trim()
+                            .rsplit('.')
+                            .next()
+                            .unwrap_or(t)
+                            .trim()
+                            .to_string();
+                        if !bare.is_empty() && bare != iface_name {
+                            embedded.push(bare);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        for embed in &embedded {
+            for s in prior_symbols {
+                if s.symbol_type != SymbolType::Function {
+                    continue;
+                }
+                let Some(qn) = s.qualified_name.as_deref() else {
+                    continue;
+                };
+                let prefix = format!("{embed}.");
+                if let Some(method_name) = qn.strip_prefix(&prefix) {
+                    if methods.iter().any(|m| m.name == method_name) {
+                        continue;
+                    }
+                    let mut promoted = s.clone();
+                    promoted.qualified_name = Some(format!("{iface_name}.{method_name}"));
+                    promoted.metadata = serde_json::json!({
+                        "language": "go",
+                        "interface_method": true,
+                        "receiver_type": iface_name,
+                        "promoted_from": embed,
+                    });
+                    methods.push(promoted);
+                }
+            }
+        }
+        Ok(methods)
     }
 
     fn calculate_cyclomatic(&self, node: Node) -> usize {
@@ -289,8 +471,11 @@ impl GoPlugin {
             let mut cursor = node.walk();
             for child in node.children(&mut cursor) {
                 match child.kind() {
-                    "if_statement" | "for_statement" | "switch_statement" | "expression_case"
-                    | "default_case" => {
+                    "if_statement" | "for_statement"
+                    | "expression_switch_statement" | "type_switch_statement"
+                    | "select_statement"
+                    | "expression_case" | "type_case" | "default_case"
+                    | "communication_case" => {
                         *complexity += 1;
                     }
                     _ => {}
@@ -314,7 +499,7 @@ impl GoPlugin {
                         *cognitive += 1 + nesting;
                         traverse(child, cognitive, nesting + 1);
                     }
-                    "switch_statement" => {
+                    "expression_switch_statement" | "type_switch_statement" | "select_statement" => {
                         *cognitive += 1 + nesting;
                         traverse(child, cognitive, nesting);
                     }
@@ -368,6 +553,287 @@ impl GoPlugin {
         traverse(node, &mut count);
         count
     }
+
+    fn type_params_of(&self, node: Node, source: &[u8]) -> Option<String> {
+        let tp = node.child_by_field_name("type_parameters")?;
+        tp.utf8_text(source).ok().map(|s| s.to_string())
+    }
+
+    fn extract_type_alias(
+        &self,
+        type_spec: Node,
+        source: &[u8],
+        file_path: &str,
+    ) -> Result<Option<Symbol>> {
+        let name = type_spec
+            .child_by_field_name("name")
+            .and_then(|n| n.utf8_text(source).ok())
+            .map(str::to_string);
+        let Some(name) = name else {
+            return Ok(None);
+        };
+        let underlying = type_spec
+            .child_by_field_name("type")
+            .and_then(|n| n.utf8_text(source).ok())
+            .map(str::to_string);
+        Ok(Some(Symbol {
+            name: name.clone(),
+            symbol_type: SymbolType::TypeAlias,
+            qualified_name: Some(name),
+            location: SourceLocation {
+                file: file_path.to_string(),
+                start_line: type_spec.start_position().row + 1,
+                end_line: type_spec.end_position().row + 1,
+                start_column: type_spec.start_position().column,
+                end_column: type_spec.end_position().column,
+            },
+            signature: underlying.clone(),
+            return_type: underlying,
+            parameters: vec![],
+            fields: vec![],
+            modifiers: vec![],
+            documentation: None,
+            metadata: serde_json::json!({ "language": "go" }),
+        }))
+    }
+
+    fn extract_imports(
+        &self,
+        import_decl: Node,
+        source: &[u8],
+        file_path: &str,
+    ) -> Result<Vec<Symbol>> {
+        let mut out = Vec::new();
+        let mut stack = vec![import_decl];
+        while let Some(node) = stack.pop() {
+            if node.kind() == "import_spec" {
+                let path = node.child_by_field_name("path").and_then(|n| {
+                    n.utf8_text(source)
+                        .ok()
+                        .map(|s| s.trim_matches('"').to_string())
+                }).or_else(|| {
+                    let mut c = node.walk();
+                    let mut found = None;
+                    for ch in node.children(&mut c) {
+                        if ch.kind() == "interpreted_string_literal" {
+                            found = ch
+                                .utf8_text(source)
+                                .ok()
+                                .map(|s| s.trim_matches('"').to_string());
+                            break;
+                        }
+                    }
+                    found
+                });
+                let alias = node
+                    .child_by_field_name("name")
+                    .and_then(|n| n.utf8_text(source).ok())
+                    .map(str::to_string);
+                if let Some(path) = path {
+                    let name = alias
+                        .clone()
+                        .unwrap_or_else(|| path.rsplit('/').next().unwrap_or(&path).to_string());
+                    out.push(Symbol {
+                        name: name.clone(),
+                        symbol_type: SymbolType::Import,
+                        qualified_name: Some(path.clone()),
+                        location: SourceLocation {
+                            file: file_path.to_string(),
+                            start_line: node.start_position().row + 1,
+                            end_line: node.end_position().row + 1,
+                            start_column: node.start_position().column,
+                            end_column: node.end_position().column,
+                        },
+                        signature: Some(path),
+                        return_type: None,
+                        parameters: vec![],
+                        fields: vec![],
+                        modifiers: vec![],
+                        documentation: None,
+                        metadata: serde_json::json!({
+                            "language": "go",
+                            "import_alias": alias,
+                        }),
+                    });
+                }
+            }
+            let mut c = node.walk();
+            for ch in node.children(&mut c) {
+                stack.push(ch);
+            }
+        }
+        Ok(out)
+    }
+
+    fn extract_consts(
+        &self,
+        const_decl: Node,
+        source: &[u8],
+        file_path: &str,
+    ) -> Result<Vec<Symbol>> {
+        let mut out = Vec::new();
+        let mut stack = vec![const_decl];
+        while let Some(node) = stack.pop() {
+            if node.kind() == "const_spec" {
+                let mut names = Vec::new();
+                if let Some(n) = node.child_by_field_name("name") {
+                    if let Ok(s) = n.utf8_text(source) {
+                        names.push(s.to_string());
+                    }
+                }
+                let mut c = node.walk();
+                for ch in node.children(&mut c) {
+                    if ch.kind() == "identifier" {
+                        if let Ok(s) = ch.utf8_text(source) {
+                            if !names.iter().any(|n| n == s) {
+                                names.push(s.to_string());
+                            }
+                        }
+                    }
+                }
+                let ty = node
+                    .child_by_field_name("type")
+                    .and_then(|n| n.utf8_text(source).ok())
+                    .map(str::to_string);
+                for name in names {
+                    out.push(Symbol {
+                        name: name.clone(),
+                        symbol_type: SymbolType::Variable,
+                        qualified_name: Some(name),
+                        location: SourceLocation {
+                            file: file_path.to_string(),
+                            start_line: node.start_position().row + 1,
+                            end_line: node.end_position().row + 1,
+                            start_column: node.start_position().column,
+                            end_column: node.end_position().column,
+                        },
+                        signature: ty.clone(),
+                        return_type: ty.clone(),
+                        parameters: vec![],
+                        fields: vec![],
+                        modifiers: vec!["const".into()],
+                        documentation: None,
+                        metadata: serde_json::json!({
+                            "language": "go",
+                            "is_const": true,
+                        }),
+                    });
+                }
+            }
+            let mut c = node.walk();
+            for ch in node.children(&mut c) {
+                stack.push(ch);
+            }
+        }
+        Ok(out)
+    }
+
+    /// Best-effort method-set satisfaction → `Implements`, and embed → `Extends`.
+    fn emit_implements_and_embeds(
+        &self,
+        symbols: &[Symbol],
+        file_path: &Path,
+        relations: &mut Vec<Relation>,
+    ) {
+        let file = file_path.to_string_lossy().to_string();
+        let loc = SourceLocation {
+            file: file.clone(),
+            start_line: 1,
+            end_line: 1,
+            start_column: 0,
+            end_column: 0,
+        };
+
+        let mut type_methods: std::collections::HashMap<String, std::collections::HashSet<String>> =
+            std::collections::HashMap::new();
+        for s in symbols {
+            if s.symbol_type != SymbolType::Function {
+                continue;
+            }
+            // Interface method stubs are not concrete implementors.
+            if s.metadata
+                .get("interface_method")
+                .and_then(|v| v.as_bool())
+                == Some(true)
+            {
+                continue;
+            }
+            if let Some(rt) = s.metadata.get("receiver_type").and_then(|v| v.as_str()) {
+                type_methods
+                    .entry(rt.to_string())
+                    .or_default()
+                    .insert(s.name.clone());
+            }
+        }
+
+        let mut iface_methods: std::collections::HashMap<String, std::collections::HashSet<String>> =
+            std::collections::HashMap::new();
+        for s in symbols {
+            if s.symbol_type != SymbolType::Function {
+                continue;
+            }
+            if s.metadata
+                .get("interface_method")
+                .and_then(|v| v.as_bool())
+                != Some(true)
+            {
+                continue;
+            }
+            if let Some(rt) = s.metadata.get("receiver_type").and_then(|v| v.as_str()) {
+                iface_methods
+                    .entry(rt.to_string())
+                    .or_default()
+                    .insert(s.name.clone());
+            }
+        }
+
+        for (ty, methods) in &type_methods {
+            for (iface, required) in &iface_methods {
+                if required.is_empty() {
+                    continue;
+                }
+                if required.iter().all(|m| methods.contains(m)) {
+                    relations.push(Relation {
+                        from: ty.clone(),
+                        to: iface.clone(),
+                        relation_type: RelationType::Implements,
+                        location: loc.clone(),
+                        metadata: serde_json::json!({ "language": "go" }),
+                        to_qualified_hint: Some(iface.clone()),
+                        to_type_hint: None,
+                    });
+                }
+            }
+        }
+
+        for s in symbols {
+            if s.symbol_type != SymbolType::Struct {
+                continue;
+            }
+            for f in &s.fields {
+                if f.visibility.as_deref() != Some("embedded") {
+                    continue;
+                }
+                let embed = f
+                    .field_type
+                    .as_deref()
+                    .unwrap_or(f.name.as_str())
+                    .trim_start_matches('*');
+                relations.push(Relation {
+                    from: s.name.clone(),
+                    to: embed.to_string(),
+                    relation_type: RelationType::Extends,
+                    location: loc.clone(),
+                    metadata: serde_json::json!({
+                        "language": "go",
+                        "embed": true,
+                    }),
+                    to_qualified_hint: Some(embed.to_string()),
+                    to_type_hint: None,
+                });
+            }
+        }
+    }
 }
 
 impl Default for GoPlugin {
@@ -415,33 +881,70 @@ impl LanguagePlugin for GoPlugin {
             plugin: &GoPlugin,
         ) -> Result<()> {
             match node.kind() {
-                "function_declaration" | "method_declaration" => {
-                    symbols.push(plugin.extract_function(node, source, file_path)?);
-                }
                 "type_declaration" => {
-                    // Check if it's a struct or interface
                     let mut cursor = node.walk();
                     for child in node.children(&mut cursor) {
-                        if child.kind() == "type_spec" {
-                            let mut spec_cursor = child.walk();
-                            for spec_child in child.children(&mut spec_cursor) {
-                                match spec_child.kind() {
-                                    "struct_type" => {
-                                        symbols
-                                            .push(plugin.extract_struct(child, source, file_path)?);
-                                        break;
+                        if child.kind() != "type_spec" {
+                            continue;
+                        }
+                        let mut handled = false;
+                        let mut spec_cursor = child.walk();
+                        for spec_child in child.children(&mut spec_cursor) {
+                            match spec_child.kind() {
+                                "struct_type" => {
+                                    let mut st =
+                                        plugin.extract_struct(child, source, file_path)?;
+                                    if let Some(tp) =
+                                        plugin.type_params_of(child, source)
+                                    {
+                                        st.metadata["type_params"] =
+                                            serde_json::Value::String(tp);
                                     }
-                                    "interface_type" => {
-                                        symbols.push(
-                                            plugin.extract_interface(child, source, file_path)?,
-                                        );
-                                        break;
-                                    }
-                                    _ => {}
+                                    symbols.push(st);
+                                    handled = true;
+                                    break;
                                 }
+                                "interface_type" => {
+                                    let iface =
+                                        plugin.extract_interface(child, source, file_path)?;
+                                    let iface_name = iface.name.clone();
+                                    symbols.push(iface);
+                                    let methods = plugin.extract_interface_methods(
+                                        spec_child,
+                                        &iface_name,
+                                        source,
+                                        file_path,
+                                        symbols,
+                                    )?;
+                                    symbols.extend(methods);
+                                    handled = true;
+                                    break;
+                                }
+                                _ => {}
+                            }
+                        }
+                        if !handled {
+                            // type alias / defined type (LF-10): `type UserID string`
+                            if let Some(alias) =
+                                plugin.extract_type_alias(child, source, file_path)?
+                            {
+                                symbols.push(alias);
                             }
                         }
                     }
+                }
+                "import_declaration" => {
+                    symbols.extend(plugin.extract_imports(node, source, file_path)?);
+                }
+                "const_declaration" => {
+                    symbols.extend(plugin.extract_consts(node, source, file_path)?);
+                }
+                "function_declaration" | "method_declaration" => {
+                    let mut func = plugin.extract_function(node, source, file_path)?;
+                    if let Some(tp) = plugin.type_params_of(node, source) {
+                        func.metadata["type_params"] = serde_json::Value::String(tp);
+                    }
+                    symbols.push(func);
                 }
                 _ => {}
             }
@@ -487,6 +990,7 @@ impl LanguagePlugin for GoPlugin {
             "go",
             &mut relations,
         );
+        self.emit_implements_and_embeds(symbols, file_path, &mut relations);
         Ok(relations)
     }
 
@@ -657,9 +1161,59 @@ func Sum(a, b int) int {
             .extract_symbols(Path::new("test.go"), source)
             .unwrap();
 
-        assert_eq!(symbols.len(), 1);
-        assert_eq!(symbols[0].name, "Reader");
-        assert_eq!(symbols[0].symbol_type, SymbolType::Interface);
+        assert!(
+            symbols
+                .iter()
+                .any(|s| s.name == "Reader" && s.symbol_type == SymbolType::Interface)
+        );
+        let method = symbols
+            .iter()
+            .find(|s| s.name == "Read" && s.symbol_type == SymbolType::Function)
+            .expect("interface method");
+        assert_eq!(method.qualified_name.as_deref(), Some("Reader.Read"));
+    }
+
+    #[test]
+    fn test_method_receiver_qualified_and_selector_calls() {
+        let source = br#"
+package demo
+
+type Alpha struct{}
+func (a *Alpha) ListItems() int { return 1 }
+
+type Beta struct{}
+func (b *Beta) ListItems() int { return 2 }
+
+type Orch struct {
+	beta *Beta
+}
+func (o *Orch) Run() int {
+	return o.beta.ListItems()
+}
+"#;
+        let plugin = GoPlugin::new().unwrap();
+        let path = Path::new("demo.go");
+        let symbols = plugin.extract_symbols(path, source).unwrap();
+        let run = symbols
+            .iter()
+            .find(|s| s.name == "Run")
+            .expect("Run");
+        assert_eq!(run.qualified_name.as_deref(), Some("Orch.Run"));
+        let rels = plugin.extract_relations(path, source, &symbols).unwrap();
+        let hit = rels.iter().find(|r| {
+            matches!(r.relation_type, RelationType::Calls)
+                && (r.from == "Orch.Run" || r.from == "Run")
+                && (r.to.contains("ListItems"))
+        });
+        assert!(hit.is_some(), "expected Run → ListItems, got {rels:?}");
+        let hit = hit.unwrap();
+        assert_eq!(hit.to_type_hint.as_deref(), Some("Beta"));
+        assert!(
+            hit.to.ends_with("Beta.ListItems") || hit.to_qualified_hint.as_deref() == Some("Beta.ListItems"),
+            "got to={} hint={:?}",
+            hit.to,
+            hit.to_qualified_hint
+        );
     }
 
     #[test]
@@ -682,6 +1236,170 @@ func helper() {}
                 .iter()
                 .any(|r| matches!(r.relation_type, RelationType::Calls) && r.to == "helper"),
             "expected Calls -> helper, got {relations:?}"
+        );
+    }
+
+    #[test]
+    fn test_implements_and_embed_extends() {
+        let source = br#"
+package demo
+
+type Runner interface {
+	Run()
+}
+
+type Remote struct{}
+func (r *Remote) Run() {}
+
+type Base struct{}
+func (b *Base) BaseMethod() {}
+
+type Derived struct {
+	Base
+}
+"#;
+        let plugin = GoPlugin::new().unwrap();
+        let path = Path::new("demo.go");
+        let symbols = plugin.extract_symbols(path, source).unwrap();
+        let relations = plugin.extract_relations(path, source, &symbols).unwrap();
+        assert!(
+            relations.iter().any(|r| {
+                matches!(r.relation_type, RelationType::Implements)
+                    && r.from == "Remote"
+                    && r.to == "Runner"
+            }),
+            "expected Remote IMPLEMENTS Runner, got {relations:?}"
+        );
+        assert!(
+            !relations.iter().any(|r| {
+                matches!(r.relation_type, RelationType::Implements) && r.from == "Runner"
+            }),
+            "interface must not IMPLEMENTS itself: {relations:?}"
+        );
+        assert!(
+            relations.iter().any(|r| {
+                matches!(r.relation_type, RelationType::Extends)
+                    && r.from == "Derived"
+                    && r.to == "Base"
+            }),
+            "expected Derived EXTENDS Base, got {relations:?}"
+        );
+    }
+
+    #[test]
+    fn test_imports_consts_alias_generics_metadata() {
+        let source = br#"
+package demo
+
+import (
+	"fmt"
+	tu "example.com/timeutil"
+)
+
+type Status int
+const (
+	StatusPending Status = iota
+	StatusActive
+)
+
+type UserID string
+
+type Box[T any] struct { Value T }
+
+func Identity[T any](v T) T { return v }
+"#;
+        let plugin = GoPlugin::new().unwrap();
+        let symbols = plugin
+            .extract_symbols(Path::new("demo.go"), source)
+            .unwrap();
+
+        assert!(
+            symbols.iter().any(|s| {
+                s.symbol_type == SymbolType::Import
+                    && s.name == "fmt"
+                    && s.qualified_name.as_deref() == Some("fmt")
+            }),
+            "missing fmt Import: {symbols:?}"
+        );
+        assert!(
+            symbols.iter().any(|s| {
+                s.symbol_type == SymbolType::Import
+                    && s.name == "tu"
+                    && s.qualified_name.as_deref() == Some("example.com/timeutil")
+            }),
+            "missing aliased Import: {symbols:?}"
+        );
+        assert!(
+            symbols.iter().any(|s| {
+                s.name == "StatusPending"
+                    && s.modifiers.iter().any(|m| m == "const")
+                    && s.metadata.get("is_const").and_then(|v| v.as_bool()) == Some(true)
+            }),
+            "missing const StatusPending"
+        );
+        assert!(
+            symbols.iter().any(|s| {
+                s.name == "UserID" && s.symbol_type == SymbolType::TypeAlias
+            }),
+            "missing TypeAlias UserID"
+        );
+        let box_sym = symbols
+            .iter()
+            .find(|s| s.name == "Box" && s.symbol_type == SymbolType::Struct)
+            .expect("Box");
+        assert!(
+            box_sym
+                .metadata
+                .get("type_params")
+                .and_then(|v| v.as_str())
+                .is_some_and(|t| t.contains("T")),
+            "Box type_params: {:?}",
+            box_sym.metadata
+        );
+        let id = symbols
+            .iter()
+            .find(|s| s.name == "Identity")
+            .expect("Identity");
+        assert!(
+            id.metadata
+                .get("type_params")
+                .and_then(|v| v.as_str())
+                .is_some_and(|t| t.contains("T")),
+            "Identity type_params: {:?}",
+            id.metadata
+        );
+    }
+}
+
+
+
+
+
+
+
+
+
+#[cfg(test)]
+mod cri_promote {
+    use super::*;
+    #[test]
+    fn runtime_service_promotes_runpodsandbox() {
+        let path = Path::new("/Users/sshaaf/git/rust/rbuilder/example/kubernetes/staging/src/k8s.io/cri-api/pkg/apis/services.go");
+        let src = std::fs::read(path).unwrap();
+        let plugin = GoPlugin::new().unwrap();
+        let symbols = plugin.extract_symbols(path, &src).unwrap();
+        let qns: Vec<_> = symbols
+            .iter()
+            .filter(|s| s.name == "RunPodSandbox")
+            .filter_map(|s| s.qualified_name.clone())
+            .collect();
+        assert!(
+            qns.iter().any(|q| q == "RuntimeService.RunPodSandbox"),
+            "{qns:?}"
+        );
+        assert!(
+            qns.iter().any(|q| q == "PodSandboxManager.RunPodSandbox"),
+            "{qns:?}"
         );
     }
 }

--- a/crates/rbuilder-plugin-api/src/call_extraction.rs
+++ b/crates/rbuilder-plugin-api/src/call_extraction.rs
@@ -35,13 +35,15 @@ pub fn callee_name(root: Node, source: &[u8]) -> Option<String> {
         }
 
         match node.kind() {
-            "identifier" | "type_identifier" => {
+            // Go method/field selectors use `field_identifier` (not `identifier`).
+            "identifier" | "type_identifier" | "field_identifier" | "property_identifier" => {
                 return node.utf8_text(source).ok().map(str::to_string);
             }
-            "field_expression" | "selector_expression" | "attribute" => {
+            "field_expression" | "selector_expression" | "attribute" | "member_expression" => {
                 if let Some(n) = node
                     .child_by_field_name("field")
                     .or_else(|| node.child_by_field_name("attribute"))
+                    .or_else(|| node.child_by_field_name("property"))
                     .or_else(|| node.child_by_field_name("name"))
                 {
                     stack.push((n, depth + 1));
@@ -111,11 +113,43 @@ pub fn push_call_relation(
         .clone()
         .unwrap_or_else(|| from_fn.name.clone());
 
-    let local_target = symbols
+    let (to_type_hint, to_qualified_hint) = if language == "go" {
+        let ty = go_call_type_hint(node, source, symbols, from_fn);
+        let qh = ty
+            .as_ref()
+            .map(|t| format!("{t}.{callee}"));
+        (ty, qh)
+    } else {
+        (None, None)
+    };
+
+    let mut meta = serde_json::json!({ "language": language });
+    if language == "go" {
+        if let Some((recv_ty, field)) = go_field_selector_meta(node, source, from_fn) {
+            meta["go_recv_type"] = serde_json::Value::String(recv_ty);
+            meta["go_field"] = serde_json::Value::String(field);
+            meta["go_callee"] = serde_json::Value::String(callee.clone());
+        }
+    }
+
+    // Prefer a unique same-file match; if ambiguous, keep bare name and rely on hints.
+    let same_file_matches: Vec<_> = symbols
         .iter()
-        .find(|s| s.name == callee && s.symbol_type == SymbolType::Function)
-        .and_then(|s| s.qualified_name.clone())
-        .unwrap_or_else(|| callee.clone());
+        .filter(|s| {
+            s.name == callee
+                && s.symbol_type == SymbolType::Function
+                && s.location.file == file_path.to_string_lossy()
+        })
+        .collect();
+    let local_target = match same_file_matches.as_slice() {
+        [only] => only
+            .qualified_name
+            .clone()
+            .unwrap_or_else(|| callee.clone()),
+        _ => to_qualified_hint
+            .clone()
+            .unwrap_or_else(|| callee.clone()),
+    };
 
     relations.push(Relation {
         from,
@@ -128,10 +162,132 @@ pub fn push_call_relation(
             start_column: node.start_position().column,
             end_column: node.end_position().column,
         },
-        metadata: serde_json::json!({ "language": language }),
-        to_qualified_hint: None,
-        to_type_hint: None,
+        metadata: meta,
+        to_qualified_hint,
+        to_type_hint,
     });
+}
+
+/// `recv.field.Method` → (receiver_type, field_name) for late resolution in GraphBuilder.
+fn go_field_selector_meta(
+    call: Node,
+    source: &[u8],
+    from_fn: &Symbol,
+) -> Option<(String, String)> {
+    let func = call.child_by_field_name("function")?;
+    if func.kind() != "selector_expression" {
+        return None;
+    }
+    let operand = func.child_by_field_name("operand")?;
+    if operand.kind() != "selector_expression" {
+        return None;
+    }
+    let inner_op = operand.child_by_field_name("operand")?;
+    let field = operand.child_by_field_name("field")?;
+    if inner_op.kind() != "identifier" {
+        return None;
+    }
+    let recv_name = inner_op.utf8_text(source).ok()?;
+    let field_name = field.utf8_text(source).ok()?.to_string();
+    let recv_ok = from_fn
+        .metadata
+        .get("receiver_name")
+        .and_then(|v| v.as_str())
+        == Some(recv_name);
+    if !recv_ok {
+        return None;
+    }
+    let recv_ty = from_fn
+        .metadata
+        .get("receiver_type")
+        .and_then(|v| v.as_str())?
+        .trim_start_matches('*')
+        .to_string();
+    Some((recv_ty, field_name))
+}
+
+/// Best-effort Go receiver/field type for `x.Method` / `x.field.Method` call sites.
+fn go_call_type_hint(
+    call: Node,
+    source: &[u8],
+    symbols: &[Symbol],
+    from_fn: &Symbol,
+) -> Option<String> {
+    let func = call.child_by_field_name("function")?;
+    if func.kind() != "selector_expression" {
+        return None;
+    }
+    let operand = func.child_by_field_name("operand")?;
+
+    // `recv.Method` where recv is the method receiver variable.
+    if operand.kind() == "identifier" {
+        let recv_name = operand.utf8_text(source).ok()?;
+        if let Some(rt) = from_fn
+            .metadata
+            .get("receiver_name")
+            .and_then(|v| v.as_str())
+        {
+            if rt == recv_name {
+                return from_fn
+                    .metadata
+                    .get("receiver_type")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.trim_start_matches('*').to_string());
+            }
+        }
+        return None;
+    }
+
+    // `recv.field.Method` — resolve `field` on the receiver struct type.
+    if operand.kind() == "selector_expression" {
+        let inner_op = operand.child_by_field_name("operand")?;
+        let field = operand.child_by_field_name("field")?;
+        if inner_op.kind() != "identifier" {
+            return None;
+        }
+        let recv_name = inner_op.utf8_text(source).ok()?;
+        let field_name = field.utf8_text(source).ok()?;
+        let recv_ok = from_fn
+            .metadata
+            .get("receiver_name")
+            .and_then(|v| v.as_str())
+            == Some(recv_name);
+        if !recv_ok {
+            return None;
+        }
+        let recv_ty = from_fn
+            .metadata
+            .get("receiver_type")
+            .and_then(|v| v.as_str())?
+            .trim_start_matches('*');
+        let owner = symbols.iter().find(|s| {
+            matches!(
+                s.symbol_type,
+                SymbolType::Struct | SymbolType::Class | SymbolType::Interface
+            ) && s.name == recv_ty
+        })?;
+        if owner.symbol_type == SymbolType::Interface {
+            return Some(owner.name.clone());
+        }
+        let ft = owner
+            .fields
+            .iter()
+            .find(|f| f.name == field_name)?
+            .field_type
+            .as_deref()?;
+        return Some(go_simple_type_name(ft));
+    }
+
+    None
+}
+
+/// `*pkg.Type` / `pkg.Type` → `Type` for Go resolution indexes.
+fn go_simple_type_name(ty: &str) -> String {
+    ty.trim_start_matches('*')
+        .rsplit(['.', '/'])
+        .next()
+        .unwrap_or(ty)
+        .to_string()
 }
 
 /// Iterative tree walk that records call relations (heap stack; bounded depth).

--- a/docs/design/cfg-design.md
+++ b/docs/design/cfg-design.md
@@ -97,7 +97,7 @@ rbuilder -f json inspect MyClass#myMethod cfg -o /tmp/cfg.json
 
 | Layer | Location |
 |-------|----------|
-| CFG unit tests | `crates/rbuilder-analysis/src/cfg.rs`, `cfg_builder.rs` (`test_go_*`, `test_java_*`, `test_rust_*`, `test_c_*`) |
+| CFG unit tests | `crates/rbuilder-analysis/src/cfg.rs`, `cfg_builder.rs` (`test_go_*`, `test_java_*`, `test_rust_*`, `test_c_*`, `test_cpp_*`) |
 | Dashboard harness | `tests/dashboard_harness.rs` (`cfg_index.json`) |
 | Playwright | `dashboard/scripts/test-graph-tabs.mjs` |
 
@@ -151,6 +151,19 @@ Honesty left: implicit `Drop` cleanup blocks are not inserted; `async_block` / `
 | `setjmp` / `longjmp` | Record setjmp sites; longjmp `Jump` back (intra-procedural approx) |
 
 Honesty left: computed `goto *ptr` not modeled; `longjmp` across functions is not inter-procedural; Duff’s-device case nesting relies on recursive case collection.
+
+### C++-specific notes
+
+| Surface | Lowering |
+|---------|----------|
+| C++17 `if` / `switch` init | `condition_clause.initializer` before `value` condition |
+| `condition_clause` | Unwrap to `value` for short-circuit / branch text |
+| `for_range_loop` | Range expr + begin/end-style header cycle |
+| `try` / `catch` / `throw` | Exception edges; throw → catch or function exit |
+| Ternary / `goto` / fallthrough | Same as C |
+| Coroutines | `co_await` / `co_yield` suspend split; `co_return` as return |
+
+Honesty left: RAII destructor cleanup blocks not inserted; overloaded `&&`/`||` still short-circuit (no type info); `lambda_expression` is not a separate sub-CFG.
 
 ---
 

--- a/docs/design/cfg-design.md
+++ b/docs/design/cfg-design.md
@@ -97,7 +97,7 @@ rbuilder -f json inspect MyClass#myMethod cfg -o /tmp/cfg.json
 
 | Layer | Location |
 |-------|----------|
-| CFG unit tests | `crates/rbuilder-analysis/src/cfg.rs`, `cfg_builder.rs` (`test_go_*`, `test_java_*`) |
+| CFG unit tests | `crates/rbuilder-analysis/src/cfg.rs`, `cfg_builder.rs` (`test_go_*`, `test_java_*`, `test_rust_*`) |
 | Dashboard harness | `tests/dashboard_harness.rs` (`cfg_index.json`) |
 | Playwright | `dashboard/scripts/test-graph-tabs.mjs` |
 
@@ -120,6 +120,22 @@ Shared `cfg_builder` now lowers Java:
 | Labels | `identifier ':' stmt` (no `label` field); labeled break/continue via `breakable_stack` |
 | `try` / `try_with_resources` | Exception edges from try entry **and** body statement blocks to catch; `finally_stack` unwind on return/throw; resources emit synthetic `name.close()` (reverse order) before user `finally` |
 | `throw_statement` | Inside try → Exception to catch; otherwise terminal `Exception` exit |
+
+### Rust-specific notes
+
+| Surface | Lowering |
+|---------|----------|
+| `if` / `if let` / `&&` `\|\|` | `let_condition` as branch; short-circuit via `wire_condition`; unwrap `else_clause` |
+| `match` + guards | Sequential arms; guard `condition` short-circuits to next arm; arm `value` field visited (returns lower) |
+| `try_expression` (`?`) | `IfTrue` success continue / `IfFalse` early `Return` exit |
+| `for pat in iter` | Iterator expression + next/body cycle |
+| `loop` | Unconditional body cycle; exit only via `break` / `return` / panic (no `IfFalse`) |
+| `while` / `while let` | Condition header + body cycle |
+| Labels | `'label:` embedded on loop nodes; `break`/`continue 'label` via `breakable_stack` |
+| `panic!` / `todo!` / `unimplemented!` / `unreachable!` | `macro_invocation` → terminal `Exception` |
+| `.await` | Branch marker + basic-block resume split |
+
+Honesty left: implicit `Drop` cleanup blocks are not inserted; `async_block` / `closure_expression` are not separate sub-CFGs (nested control flow inside them is still walked when reachable).
 
 ---
 

--- a/docs/design/cfg-design.md
+++ b/docs/design/cfg-design.md
@@ -97,15 +97,20 @@ rbuilder -f json inspect MyClass#myMethod cfg -o /tmp/cfg.json
 
 | Layer | Location |
 |-------|----------|
-| CFG unit tests | `crates/rbuilder-analysis/src/cfg.rs` |
+| CFG unit tests | `crates/rbuilder-analysis/src/cfg.rs`, `cfg_builder.rs` (`test_go_*` for Go if-init / for_clause / switch cases) |
 | Dashboard harness | `tests/dashboard_harness.rs` (`cfg_index.json`) |
 | Playwright | `dashboard/scripts/test-graph-tabs.mjs` |
 
 Screenshots: `capture-design-screenshots.mjs` → `docs/images/design/cfg/`.
+
+### Go-specific notes
+
+See [go-language-coverage.md](./go-language-coverage.md#go-cfg-lowering-tree-sitter) for the Tree-sitter Go checklist vs current lowering. Remaining honesty: `go` does not fork a parallel CFG; defer multiplicity inside loops is static-once.
 
 ---
 
 ## 8. Related docs
 
 - [PDG design](pdg-design.md) · [Dominance design](dominance-design.md)
+- [Go language coverage](go-language-coverage.md) — LF-11…LF-15 CFG expectations
 - [Dashboard design](../dashboard-design.md) — Phase 4 CFG export

--- a/docs/design/cfg-design.md
+++ b/docs/design/cfg-design.md
@@ -97,7 +97,7 @@ rbuilder -f json inspect MyClass#myMethod cfg -o /tmp/cfg.json
 
 | Layer | Location |
 |-------|----------|
-| CFG unit tests | `crates/rbuilder-analysis/src/cfg.rs`, `cfg_builder.rs` (`test_go_*` for Go if-init / for_clause / switch cases) |
+| CFG unit tests | `crates/rbuilder-analysis/src/cfg.rs`, `cfg_builder.rs` (`test_go_*`, `test_java_*`) |
 | Dashboard harness | `tests/dashboard_harness.rs` (`cfg_index.json`) |
 | Playwright | `dashboard/scripts/test-graph-tabs.mjs` |
 
@@ -106,6 +106,20 @@ Screenshots: `capture-design-screenshots.mjs` → `docs/images/design/cfg/`.
 ### Go-specific notes
 
 See [go-language-coverage.md](./go-language-coverage.md#go-cfg-lowering-tree-sitter) for the Tree-sitter Go checklist vs current lowering. Remaining honesty: `go` does not fork a parallel CFG; defer multiplicity inside loops is static-once.
+
+### Java-specific notes
+
+Shared `cfg_builder` now lowers Java:
+
+| Surface | Lowering |
+|---------|----------|
+| `if` / `&&` `\|\|` | Unwrap `parenthesized_expression`; short-circuit via `wire_condition` |
+| Classic `for` | Fields `init` / `condition` / `update`; `continue` → update block |
+| `enhanced_for_statement` | Header branch + body cycle |
+| `switch_statement` / `switch_expression` | `switch_block_statement_group` (implicit fallthrough) and `switch_rule` (arrow, no fallthrough); `return switch (...)` visits nested switch |
+| Labels | `identifier ':' stmt` (no `label` field); labeled break/continue via `breakable_stack` |
+| `try` / `try_with_resources` | Exception edges from try entry **and** body statement blocks to catch; `finally_stack` unwind on return/throw; resources emit synthetic `name.close()` (reverse order) before user `finally` |
+| `throw_statement` | Inside try → Exception to catch; otherwise terminal `Exception` exit |
 
 ---
 

--- a/docs/design/cfg-design.md
+++ b/docs/design/cfg-design.md
@@ -97,7 +97,7 @@ rbuilder -f json inspect MyClass#myMethod cfg -o /tmp/cfg.json
 
 | Layer | Location |
 |-------|----------|
-| CFG unit tests | `crates/rbuilder-analysis/src/cfg.rs`, `cfg_builder.rs` (`test_go_*`, `test_java_*`, `test_rust_*`) |
+| CFG unit tests | `crates/rbuilder-analysis/src/cfg.rs`, `cfg_builder.rs` (`test_go_*`, `test_java_*`, `test_rust_*`, `test_c_*`) |
 | Dashboard harness | `tests/dashboard_harness.rs` (`cfg_index.json`) |
 | Playwright | `dashboard/scripts/test-graph-tabs.mjs` |
 
@@ -136,6 +136,21 @@ Shared `cfg_builder` now lowers Java:
 | `.await` | Branch marker + basic-block resume split |
 
 Honesty left: implicit `Drop` cleanup blocks are not inserted; `async_block` / `closure_expression` are not separate sub-CFGs (nested control flow inside them is still walked when reachable).
+
+### C-specific notes
+
+| Surface | Lowering |
+|---------|----------|
+| `if` / `&&` `\|\|` | Unwrap `parenthesized_expression` and C++ `condition_clause`; short-circuit via `wire_condition` |
+| `for` | Fields `initializer` / `condition` / `update`; `continue` → update |
+| `do` / `while` | Body-then-condition cycle; condition on header block |
+| `switch` / `case_statement` | Implicit fallthrough between cases; `default` = case with no `value` |
+| Ternary | `conditional_expression` → IfTrue/IfFalse merge |
+| `goto` / labels | `statement_identifier` label field; eager label blocks for forward jumps |
+| `abort` / `exit` / `_Exit` | Terminal `Exception` exit |
+| `setjmp` / `longjmp` | Record setjmp sites; longjmp `Jump` back (intra-procedural approx) |
+
+Honesty left: computed `goto *ptr` not modeled; `longjmp` across functions is not inter-procedural; Duff’s-device case nesting relies on recursive case collection.
 
 ---
 

--- a/docs/design/cfg-design.md
+++ b/docs/design/cfg-design.md
@@ -165,6 +165,26 @@ Honesty left: computed `goto *ptr` not modeled; `longjmp` across functions is no
 
 Honesty left: RAII destructor cleanup blocks not inserted; overloaded `&&`/`||` still short-circuit (no type info); `lambda_expression` is not a separate sub-CFG.
 
+### C#-specific notes
+
+| Surface | Lowering |
+|---------|----------|
+| `if` / `&&` `\|\|` | Short-circuit via `wire_condition` (same as Java/C) |
+| `for` | Init / condition / update; `continue` → update |
+| `foreach` | Collection expr + `for-each` header cycle (`MoveNext`-style) |
+| `switch_statement` / `switch_section` | Case fan-out; **no** implicit fallthrough; `when` guards before body |
+| `switch_expression` / `switch_expression_arm` | Sequential pattern arms (C#); Java `switch_expression` falls back to statement lowering |
+| `??` / `?.` | Null-coalesce and null-conditional branch splits |
+| `try` / `catch` / `when` / `finally` | Exception edges; catch filter before body; finally on exit |
+| `using` / `lock` | Finally-style `Dispose()` / `Monitor.Exit` on all exits (statement **and** `using var` declaration) |
+| `await` | Async state-machine split: `IfTrue` resume / `IfFalse` suspend exit |
+| `yield return` / `yield break` | Suspend split / terminal exit through finallies |
+| `goto` / labels | Unconditional jump within method |
+| `goto case` / `goto default` | Resolve to pre-created switch section entry blocks |
+| Lambdas / local functions | Disconnected sub-CFG (`Jump` from definition); body returns use nested exit |
+
+Honesty left: full async state-machine (multiple awaits / `MoveNext` resume table) is still a per-await bifurcate, not a global state enum; expression-bodied members and iterators beyond `yield` are not specialized further.
+
 ---
 
 ## 8. Related docs

--- a/docs/design/go-language-coverage.md
+++ b/docs/design/go-language-coverage.md
@@ -1,0 +1,81 @@
+# Go language feature coverage (ecommerce-go)
+
+**Purpose:** Canonical checklist of Go language surfaces that rBuilder must index and analyze correctly. Fixture code lives under `rbuilder-tests/ecommerce-go/internal/langfeatures/`. Expected graph facts live in `ecommerce-go/correctness/expected-facts.json` (ids prefixed `lf_`).
+
+**Tracking:** [sshaaf/rBuilder#46](https://github.com/sshaaf/rBuilder/issues/46) · plan: [go-tier1-completion-plan.md](./go-tier1-completion-plan.md)
+
+**Honesty limits (not “optional gaps”):** no full points-to across reflection/`any` casts; ambiguous multi-impl interface edges may be multi-target or annotated dynamic — but must not be silently dropped.
+
+---
+
+## Feature matrix
+
+| ID | Language feature | Fixture file | Probe symbols (names) | Expected graph / analysis | Severity |
+|----|------------------|--------------|------------------------|---------------------------|----------|
+| LF-01 | Package function call | `calls_basic.go` | `LfPkgCaller` → `LfPkgCallee` | `CALLS` edge | required |
+| LF-02 | Method call same type | `methods.go` | `(*LfCart).Checkout` → `(*LfCart).validate` | `CALLS`; receiver FQN `LfCart.Checkout` | required |
+| LF-03 | Method call cross-type same name | `methods.go` | `(*LfOrchestrator).Run` → `(*LfBetaStore).ListItems` (not `LfAlphaStore.ListItems`) | Correct resolution under name collision | required |
+| LF-04 | Interface method call | `interfaces.go` | `(*LfRuntimeClient).Start` → `RunSandbox` via `LfRuntime` | `CALLS` to impl(s); interface method symbol exists | required |
+| LF-05 | Multiple interface implementations | `interfaces.go` | `LfRemoteRuntime.RunSandbox`, `LfFakeRuntime.RunSandbox` | Both method symbols; implements / satisfaction link to `LfRuntime` | required |
+| LF-06 | Struct embedding (anonymous field) | `embedding.go` | `LfDerived` embeds `LfBase` | Embedded field in `fields[]`; embed/`EXTENDS`-like or `CONTAINS` relation | required |
+| LF-07 | Promoted method via embed | `embedding.go` | `(*LfDerived).UseBase` → `(*LfBase).BaseMethod` | `CALLS` to promoted / base method | required |
+| LF-08 | `var` declaration def-use | `vars.go` | `LfVarFlow` | PDG/def-use sees `var x int` / `var s string` defs | required |
+| LF-09 | Short var `:=` | `vars.go` | `LfShortVarFlow` | def-use for `:=` (already partially covered by harness) | required |
+| LF-10 | Const + typed iota / alias | `vars.go` | `LfStatus`, `LfStatusPending`, type alias `LfUserID` | TypeAlias / const or Variable symbols | required |
+| LF-11 | Expression switch | `control.go` | `LfExprSwitch` | Complexity counts cases; CFG lowers case `statement_list` (Return edges from case bodies) | required |
+| LF-12 | Type switch | `control.go` | `LfTypeSwitch` | CFG/complexity include `type_case`; case bodies lowered | required |
+| LF-13 | `select` + channel | `control.go` | `LfSelectLoop` | CFG select arms via same case lowering; complexity counts `communication_case` | required |
+| LF-14 | `defer` | `control.go` | `LfWithDefer` | CFG records defer; return/panic route through defer chain LIFO | required |
+| LF-15 | `go` statement | `control.go` | `LfSpawn` | CFG records go stmt; call edge to spawned func name | required |
+| LF-16 | Generics (func + type) | `generics.go` | `LfIdentity[T]`, `LfBox[T]` | Symbols retained; calls to `LfIdentity` resolve | required |
+| LF-17 | Imports | `imports_probe.go` | import of `fmt` / internal pkg | `Import` symbols or `IMPORTS` edges | required |
+| LF-18 | Constructor `NewT` | `methods.go` | `NewLfCart` | `LfCart.<init>`, `is_constructor` | required |
+| LF-19 | Receiver field write (CPG) | `fieldwrite.go` | `(*LfOrderDTO).MarkProcessed` writes `Status` | `cpg mutations` / field-write index hit with `--exclude-ctors` | required |
+| LF-20 | Multi-value return | `methods.go` | `(*LfCart).Totals` | Structured or preserved return signature string | best_effort |
+| LF-21 | Struct tags | `fieldwrite.go` | `LfOrderDTO.Status` `json:"status"` | Tag in field metadata | best_effort |
+
+---
+
+## How to re-verify
+
+```bash
+# From rBuilder repo root
+cargo build --release
+./target/release/rbuilder discover rbuilder-tests/ecommerce-go -l go -e vendor \
+  --with-cfg --with-taint -v
+
+# Correctness suite (includes lf_* facts once present)
+cargo test --test graph_correctness go -- --nocapture
+
+# Spot-check call edges
+./target/release/rbuilder -r rbuilder-tests/ecommerce-go -f json \
+  gql "MATCH (a:Function)-[:CALLS]->(b:Function) WHERE a.name = 'Run' RETURN a,b"
+```
+
+When adding a new Go surface, **add a row here**, a fixture symbol, and an `lf_*` expected-fact before claiming support.
+
+---
+
+## Go CFG lowering (Tree-sitter)
+
+Shared builder: `crates/rbuilder-analysis/src/cfg_builder.rs`. Unit tests: `cfg_builder::tests::test_go_*`.
+
+| Construct | Lowering | Status |
+|-----------|----------|--------|
+| Straight-line (`var` / `:=` / assign / call / `i++` / send) | Basic-block statements | done |
+| `if` + `else` / `else if` | Condition Branch + `IfTrue`/`IfFalse` | done |
+| `if init; cond` | Init statement **before** condition block | done |
+| `for` three-part (`for_clause`) | Init → cond header → body → **update** → cond; `continue` → update | done |
+| `for` while-style / infinite / `range` | Header + body cycle (range text on header) | done (coarse range) |
+| Expr / type `switch` + `select` | Fan-out; case **`statement_list` lowered** (returns emit `Return`) | done |
+| `switch init; …` | Init before branch | done |
+| Unlabeled `break` / `continue` | Exit / continue-target (innermost for/switch/select) | done |
+| Labeled `break` / `continue` | Jump to labeled loop/switch exit or continue-target | done |
+| `go` | Expression in BB; no parallel CFG fork | approx (LF-15) |
+| `defer` | Register on stack; return/panic unwind LIFO as FunctionCall blocks | done |
+| `fallthrough` | Jump from case body into next case body | done |
+| `goto` / `labeled_statement` | Eager label blocks; forward/back `goto` → Jump | done |
+| `&&` / `\|\|` short-circuit | Condition lowered into chained IfTrue/IfFalse | done |
+| `panic` | Call + unwind through active defers (Exception terminal) | done |
+
+Honesty: `go` does not fork a parallel CFG; defer is a static stack (loop-deferred multiplicity not modeled).

--- a/docs/tier-1-language-support.md
+++ b/docs/tier-1-language-support.md
@@ -39,7 +39,7 @@ A language is **fully supported** when all rows are ✅ and backed by automated 
 | A3 | **Symbols:** functions/methods with name, location, signature, parameters | `extract_symbols()` |
 | A4 | **Symbols:** types (class/struct/interface/enum as appropriate) | `extract_symbols()` |
 | A5 | **Relations:** `Calls` between functions | `extract_relations()` — use `rbuilder_plugin_api::walk_calls` or language-specific walker |
-| A6 | **Relations (OOP):** `Extends` / `Implements` where the language has inheritance | Java-style plugins; optional for Go/Rust |
+| A6 | **Relations (OOP / composition):** `Extends` / `Implements` (or language equivalent: Go struct embed → `Extends`, method-set satisfaction → `Implements`; Rust trait impls when extracted) | Required for Tier 1 — not optional. Document honesty limits (no full points-to) separately. |
 | A7 | Cyclomatic / cognitive complexity for functions | `calculate_complexity()` |
 | A8 | Entry in `languages.toml` with `handler = "custom"` | Repo root |
 | A9 | Registered in `rbuilder-languages` | `crates/rbuilder-languages/src/lib.rs` |

--- a/rbuilder-tests/correctness/SCHEMA.md
+++ b/rbuilder-tests/correctness/SCHEMA.md
@@ -118,6 +118,10 @@ Each `ecommerce-*` app should include a small intentional call chain:
 
 `correctnessRoot` → `correctnessMid` → `correctnessLeaf`
 
+Additionally, each language ships **CFG feature probes** (`CfgFeatures` / `cfg_features.*`) that exercise
+control-flow lowering unique to that language (short-circuit, loops, switch, try/cleanup, await, …).
+Those symbols are asserted via `cfg.min_blocks` + `cfg.statements_contain` in `expected-facts.json`.
+
 (Language-idiomatic spellings: `correctness_root`, `CorrectnessRoot`, etc.)
 
 Prefer **direct calls** with **no intermediate locals** assigned from call results **in C/C++**.

--- a/rbuilder-tests/ecommerce-c/correctness/expected-facts.json
+++ b/rbuilder-tests/ecommerce-c/correctness/expected-facts.json
@@ -9,7 +9,9 @@
   },
   "symbols": {
     "correctnessRoot": {
-      "match": { "name": "correctness_root" },
+      "match": {
+        "name": "correctness_root"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -18,36 +20,63 @@
         "file_suffix": "correctness_harness.c",
         "language": "c"
       },
-      "exact_callees": ["correctness_mid"],
+      "exact_callees": [
+        "correctness_mid"
+      ],
       "exact_callers": [],
       "blast": {
         "exact_direct_callers": [],
         "exact_impact_zone": []
       },
       "ast": {
-        "must_call": ["correctness_mid"],
-        "statements_contain": ["flag", "return correctness_mid() * 2;"],
-        "statement_kinds_any": ["Branch", "Return"]
+        "must_call": [
+          "correctness_mid"
+        ],
+        "statements_contain": [
+          "flag",
+          "return correctness_mid() * 2;"
+        ],
+        "statement_kinds_any": [
+          "Branch",
+          "Return"
+        ]
       },
       "cfg": {
         "exact_block_count": 7,
         "exact_edge_count": 6,
-        "exact_edge_kinds": ["iffalse", "iftrue", "next", "next", "return", "return"],
-        "statements_contain": ["correctness_mid()"]
+        "exact_edge_kinds": [
+          "iffalse",
+          "iftrue",
+          "next",
+          "next",
+          "return",
+          "return"
+        ],
+        "statements_contain": [
+          "correctness_mid()"
+        ]
       },
       "pdg": {
         "exact_data_deps": 0,
         "exact_control_deps": 1,
         "exact_node_count": 3,
-        "exact_node_kinds": ["Branch", "Return", "Return"],
-        "node_labels_contain": ["correctness_mid()"]
+        "exact_node_kinds": [
+          "Branch",
+          "Return",
+          "Return"
+        ],
+        "node_labels_contain": [
+          "correctness_mid()"
+        ]
       },
       "dom": {
         "exact_block_count": 7
       }
     },
     "correctnessMid": {
-      "match": { "name": "correctness_mid" },
+      "match": {
+        "name": "correctness_mid"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -56,39 +85,65 @@
         "file_suffix": "correctness_harness.c",
         "language": "c"
       },
-      "exact_callees": ["correctness_leaf"],
-      "exact_callers": ["correctness_root"],
+      "exact_callees": [
+        "correctness_leaf"
+      ],
+      "exact_callers": [
+        "correctness_root"
+      ],
       "blast": {
-        "exact_direct_callers": ["correctness_root"],
-        "exact_impact_zone": ["correctness_root"],
+        "exact_direct_callers": [
+          "correctness_root"
+        ],
+        "exact_impact_zone": [
+          "correctness_root"
+        ],
         "min_score": 0.1
       },
       "ast": {
-        "must_call": ["correctness_leaf"],
-        "statements_contain": ["return correctness_leaf() + 1;"],
-        "exact_statement_kinds": ["Return"]
+        "must_call": [
+          "correctness_leaf"
+        ],
+        "statements_contain": [
+          "return correctness_leaf() + 1;"
+        ],
+        "exact_statement_kinds": [
+          "Return"
+        ]
       },
       "cfg": {
         "exact_block_count": 2,
         "exact_edge_count": 1,
-        "exact_edge_kinds": ["return"]
+        "exact_edge_kinds": [
+          "return"
+        ]
       },
       "pdg": {
         "exact_data_deps": 0,
         "exact_control_deps": 0,
         "exact_node_count": 1,
-        "exact_node_kinds": ["Return"]
+        "exact_node_kinds": [
+          "Return"
+        ]
       },
       "dom": {
         "exact_block_count": 2,
         "exact_idom": [
-          { "block": 0, "immediate_dominator": 1 },
-          { "block": 1, "immediate_dominator": 1 }
+          {
+            "block": 0,
+            "immediate_dominator": 1
+          },
+          {
+            "block": 1,
+            "immediate_dominator": 1
+          }
         ]
       }
     },
     "correctnessLeaf": {
-      "match": { "name": "correctness_leaf" },
+      "match": {
+        "name": "correctness_leaf"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -98,61 +153,188 @@
         "language": "c"
       },
       "exact_callees": [],
-      "exact_callers": ["correctness_mid"],
+      "exact_callers": [
+        "correctness_mid"
+      ],
       "blast": {
-        "exact_direct_callers": ["correctness_mid"],
-        "exact_impact_zone": ["correctness_mid", "correctness_root"],
+        "exact_direct_callers": [
+          "correctness_mid"
+        ],
+        "exact_impact_zone": [
+          "correctness_mid",
+          "correctness_root"
+        ],
         "min_score": 0.1
       },
       "ast": {
-        "statements_contain": ["return 42;"],
-        "exact_statement_kinds": ["Return"]
+        "statements_contain": [
+          "return 42;"
+        ],
+        "exact_statement_kinds": [
+          "Return"
+        ]
       },
       "cfg": {
         "exact_block_count": 2,
         "exact_edge_count": 1,
-        "exact_edge_kinds": ["return"]
+        "exact_edge_kinds": [
+          "return"
+        ]
       },
       "pdg": {
         "exact_data_deps": 0,
         "exact_control_deps": 0,
         "exact_node_count": 1,
-        "exact_node_kinds": ["Return"]
+        "exact_node_kinds": [
+          "Return"
+        ]
       },
-      "dom": { "exact_block_count": 2 }
+      "dom": {
+        "exact_block_count": 2
+      }
+    },
+    "cfg_short_circuit": {
+      "match": {
+        "name": "cfg_short_circuit"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfg_short_circuit",
+        "file_suffix": "cfg_features.c",
+        "language": "c"
+      },
+      "cfg": {
+        "min_blocks": 6,
+        "statements_contain": [
+          "a",
+          "b"
+        ]
+      }
+    },
+    "cfg_do_while": {
+      "match": {
+        "name": "cfg_do_while"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfg_do_while",
+        "file_suffix": "cfg_features.c",
+        "language": "c"
+      },
+      "cfg": {
+        "min_blocks": 4,
+        "statements_contain": []
+      }
+    },
+    "cfg_goto_label": {
+      "match": {
+        "name": "cfg_goto_label"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfg_goto_label",
+        "file_suffix": "cfg_features.c",
+        "language": "c"
+      },
+      "cfg": {
+        "min_blocks": 5,
+        "statements_contain": [
+          "goto"
+        ]
+      }
+    },
+    "cfg_switch_fallthrough": {
+      "match": {
+        "name": "cfg_switch_fallthrough"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfg_switch_fallthrough",
+        "file_suffix": "cfg_features.c",
+        "language": "c"
+      },
+      "cfg": {
+        "min_blocks": 5,
+        "statements_contain": []
+      }
+    },
+    "cfg_ternary": {
+      "match": {
+        "name": "cfg_ternary"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfg_ternary",
+        "file_suffix": "cfg_features.c",
+        "language": "c"
+      },
+      "cfg": {
+        "min_blocks": 4,
+        "statements_contain": []
+      }
     }
   },
   "invariants": {
     "B1_blast_vs_calls": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessLeaf", "correctnessMid"]
+      "symbols": [
+        "correctnessLeaf",
+        "correctnessMid"
+      ]
     },
-    "B2_gql_calls_nonzero": { "enabled": true, "severity": "required" },
+    "B2_gql_calls_nonzero": {
+      "enabled": true,
+      "severity": "required"
+    },
     "B5_inspect_cfg_present": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B6_cfg_calls_subset_of_calls_edges": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid"
+      ]
     },
     "B7_pdg_lines_subset_cfg": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B8_dom_blocks_match_cfg": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B9_blast_target_name": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     }
   }
 }

--- a/rbuilder-tests/ecommerce-c/correctness/expected-facts.json
+++ b/rbuilder-tests/ecommerce-c/correctness/expected-facts.json
@@ -26,28 +26,24 @@
       },
       "ast": {
         "must_call": ["correctness_mid"],
-        "statements_contain": ["if (flag)", "return correctness_mid() * 2;"],
+        "statements_contain": ["flag", "return correctness_mid() * 2;"],
         "statement_kinds_any": ["Branch", "Return"]
       },
       "cfg": {
-        "exact_block_count": 5,
-        "exact_edge_count": 5,
-        "exact_edge_kinds": ["iffalse", "iftrue", "next", "next", "return"],
+        "exact_block_count": 7,
+        "exact_edge_count": 6,
+        "exact_edge_kinds": ["iffalse", "iftrue", "next", "next", "return", "return"],
         "statements_contain": ["correctness_mid()"]
       },
       "pdg": {
         "exact_data_deps": 0,
-        "exact_control_deps": 0,
-        "exact_node_count": 2,
-        "exact_node_kinds": ["Branch", "Return"],
+        "exact_control_deps": 1,
+        "exact_node_count": 3,
+        "exact_node_kinds": ["Branch", "Return", "Return"],
         "node_labels_contain": ["correctness_mid()"]
       },
       "dom": {
-        "exact_block_count": 5,
-        "idom_contains": [
-          { "block": 3, "immediate_dominator": 3 },
-          { "block": 4, "immediate_dominator": 3 }
-        ]
+        "exact_block_count": 7
       }
     },
     "correctnessMid": {

--- a/rbuilder-tests/ecommerce-c/src/cfg_features.c
+++ b/rbuilder-tests/ecommerce-c/src/cfg_features.c
@@ -1,0 +1,47 @@
+/* CFG feature probes for rBuilder expected-facts (C lowering coverage). */
+
+int cfg_short_circuit(int a, int b) {
+    if (a && b) {
+        return 1;
+    }
+    return 0;
+}
+
+int cfg_do_while(int n) {
+    int i = 0;
+    int total = 0;
+    do {
+        total += i;
+        i++;
+    } while (i < n);
+    return total;
+}
+
+int cfg_goto_label(int x) {
+    if (x < 0) {
+        goto done;
+    }
+    x++;
+done:
+    return x;
+}
+
+int cfg_switch_fallthrough(int x) {
+    int r = 0;
+    switch (x) {
+    case 1:
+        r += 1;
+        /* fall through */
+    case 2:
+        r += 2;
+        break;
+    default:
+        r = 0;
+        break;
+    }
+    return r;
+}
+
+int cfg_ternary(int x) {
+    return x > 0 ? x : -x;
+}

--- a/rbuilder-tests/ecommerce-cpp/correctness/expected-facts.json
+++ b/rbuilder-tests/ecommerce-cpp/correctness/expected-facts.json
@@ -26,28 +26,24 @@
       },
       "ast": {
         "must_call": ["correctnessMid"],
-        "statements_contain": ["if (flag)", "return correctnessMid() * 2;"],
+        "statements_contain": ["flag", "return correctnessMid() * 2;"],
         "statement_kinds_any": ["Branch", "Return"]
       },
       "cfg": {
-        "exact_block_count": 5,
-        "exact_edge_count": 5,
-        "exact_edge_kinds": ["iffalse", "iftrue", "next", "next", "return"],
+        "exact_block_count": 7,
+        "exact_edge_count": 6,
+        "exact_edge_kinds": ["iffalse", "iftrue", "next", "next", "return", "return"],
         "statements_contain": ["correctnessMid()"]
       },
       "pdg": {
         "exact_data_deps": 0,
-        "exact_control_deps": 0,
-        "exact_node_count": 2,
-        "exact_node_kinds": ["Branch", "Return"],
+        "exact_control_deps": 1,
+        "exact_node_count": 3,
+        "exact_node_kinds": ["Branch", "Return", "Return"],
         "node_labels_contain": ["correctnessMid()"]
       },
       "dom": {
-        "exact_block_count": 5,
-        "idom_contains": [
-          { "block": 3, "immediate_dominator": 3 },
-          { "block": 4, "immediate_dominator": 3 }
-        ]
+        "exact_block_count": 7
       }
     },
     "correctnessMid": {

--- a/rbuilder-tests/ecommerce-cpp/correctness/expected-facts.json
+++ b/rbuilder-tests/ecommerce-cpp/correctness/expected-facts.json
@@ -9,7 +9,9 @@
   },
   "symbols": {
     "correctnessRoot": {
-      "match": { "name": "correctnessRoot" },
+      "match": {
+        "name": "correctnessRoot"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -18,36 +20,63 @@
         "file_suffix": "correctness_harness.cpp",
         "language": "cpp"
       },
-      "exact_callees": ["correctnessMid"],
+      "exact_callees": [
+        "correctnessMid"
+      ],
       "exact_callers": [],
       "blast": {
         "exact_direct_callers": [],
         "exact_impact_zone": []
       },
       "ast": {
-        "must_call": ["correctnessMid"],
-        "statements_contain": ["flag", "return correctnessMid() * 2;"],
-        "statement_kinds_any": ["Branch", "Return"]
+        "must_call": [
+          "correctnessMid"
+        ],
+        "statements_contain": [
+          "flag",
+          "return correctnessMid() * 2;"
+        ],
+        "statement_kinds_any": [
+          "Branch",
+          "Return"
+        ]
       },
       "cfg": {
         "exact_block_count": 7,
         "exact_edge_count": 6,
-        "exact_edge_kinds": ["iffalse", "iftrue", "next", "next", "return", "return"],
-        "statements_contain": ["correctnessMid()"]
+        "exact_edge_kinds": [
+          "iffalse",
+          "iftrue",
+          "next",
+          "next",
+          "return",
+          "return"
+        ],
+        "statements_contain": [
+          "correctnessMid()"
+        ]
       },
       "pdg": {
         "exact_data_deps": 0,
         "exact_control_deps": 1,
         "exact_node_count": 3,
-        "exact_node_kinds": ["Branch", "Return", "Return"],
-        "node_labels_contain": ["correctnessMid()"]
+        "exact_node_kinds": [
+          "Branch",
+          "Return",
+          "Return"
+        ],
+        "node_labels_contain": [
+          "correctnessMid()"
+        ]
       },
       "dom": {
         "exact_block_count": 7
       }
     },
     "correctnessMid": {
-      "match": { "name": "correctnessMid" },
+      "match": {
+        "name": "correctnessMid"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -56,33 +85,55 @@
         "file_suffix": "correctness_harness.cpp",
         "language": "cpp"
       },
-      "exact_callees": ["correctnessLeaf"],
-      "exact_callers": ["correctnessRoot"],
+      "exact_callees": [
+        "correctnessLeaf"
+      ],
+      "exact_callers": [
+        "correctnessRoot"
+      ],
       "blast": {
-        "exact_direct_callers": ["correctnessRoot"],
-        "exact_impact_zone": ["correctnessRoot"],
+        "exact_direct_callers": [
+          "correctnessRoot"
+        ],
+        "exact_impact_zone": [
+          "correctnessRoot"
+        ],
         "min_score": 0.1
       },
       "ast": {
-        "must_call": ["correctnessLeaf"],
-        "statements_contain": ["return correctnessLeaf() + 1;"],
-        "exact_statement_kinds": ["Return"]
+        "must_call": [
+          "correctnessLeaf"
+        ],
+        "statements_contain": [
+          "return correctnessLeaf() + 1;"
+        ],
+        "exact_statement_kinds": [
+          "Return"
+        ]
       },
       "cfg": {
         "exact_block_count": 2,
         "exact_edge_count": 1,
-        "exact_edge_kinds": ["return"]
+        "exact_edge_kinds": [
+          "return"
+        ]
       },
       "pdg": {
         "exact_data_deps": 0,
         "exact_control_deps": 0,
         "exact_node_count": 1,
-        "exact_node_kinds": ["Return"]
+        "exact_node_kinds": [
+          "Return"
+        ]
       },
-      "dom": { "exact_block_count": 2 }
+      "dom": {
+        "exact_block_count": 2
+      }
     },
     "correctnessLeaf": {
-      "match": { "name": "correctnessLeaf" },
+      "match": {
+        "name": "correctnessLeaf"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -92,61 +143,190 @@
         "language": "cpp"
       },
       "exact_callees": [],
-      "exact_callers": ["correctnessMid"],
+      "exact_callers": [
+        "correctnessMid"
+      ],
       "blast": {
-        "exact_direct_callers": ["correctnessMid"],
-        "exact_impact_zone": ["correctnessMid", "correctnessRoot"],
+        "exact_direct_callers": [
+          "correctnessMid"
+        ],
+        "exact_impact_zone": [
+          "correctnessMid",
+          "correctnessRoot"
+        ],
         "min_score": 0.1
       },
       "ast": {
-        "statements_contain": ["return 42;"],
-        "exact_statement_kinds": ["Return"]
+        "statements_contain": [
+          "return 42;"
+        ],
+        "exact_statement_kinds": [
+          "Return"
+        ]
       },
       "cfg": {
         "exact_block_count": 2,
         "exact_edge_count": 1,
-        "exact_edge_kinds": ["return"]
+        "exact_edge_kinds": [
+          "return"
+        ]
       },
       "pdg": {
         "exact_data_deps": 0,
         "exact_control_deps": 0,
         "exact_node_count": 1,
-        "exact_node_kinds": ["Return"]
+        "exact_node_kinds": [
+          "Return"
+        ]
       },
-      "dom": { "exact_block_count": 2 }
+      "dom": {
+        "exact_block_count": 2
+      }
+    },
+    "cfgShortCircuit": {
+      "match": {
+        "name": "cfgShortCircuit"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfgShortCircuit",
+        "file_suffix": "cfg_features.cpp",
+        "language": "cpp"
+      },
+      "cfg": {
+        "min_blocks": 6,
+        "statements_contain": [
+          "a",
+          "b"
+        ]
+      }
+    },
+    "cfgRangeFor": {
+      "match": {
+        "name": "cfgRangeFor"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfgRangeFor",
+        "file_suffix": "cfg_features.cpp",
+        "language": "cpp"
+      },
+      "cfg": {
+        "min_blocks": 4,
+        "statements_contain": [
+          "for-range"
+        ]
+      }
+    },
+    "cfgTryCatch": {
+      "match": {
+        "name": "cfgTryCatch"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfgTryCatch",
+        "file_suffix": "cfg_features.cpp",
+        "language": "cpp"
+      },
+      "cfg": {
+        "min_blocks": 6,
+        "statements_contain": []
+      }
+    },
+    "cfgIfInit": {
+      "match": {
+        "name": "cfgIfInit"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfgIfInit",
+        "file_suffix": "cfg_features.cpp",
+        "language": "cpp"
+      },
+      "cfg": {
+        "min_blocks": 5,
+        "statements_contain": [
+          "x"
+        ]
+      }
+    },
+    "cfgTernary": {
+      "match": {
+        "name": "cfgTernary"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfgTernary",
+        "file_suffix": "cfg_features.cpp",
+        "language": "cpp"
+      },
+      "cfg": {
+        "min_blocks": 4,
+        "statements_contain": []
+      }
     }
   },
   "invariants": {
     "B1_blast_vs_calls": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessLeaf", "correctnessMid"]
+      "symbols": [
+        "correctnessLeaf",
+        "correctnessMid"
+      ]
     },
-    "B2_gql_calls_nonzero": { "enabled": true, "severity": "required" },
+    "B2_gql_calls_nonzero": {
+      "enabled": true,
+      "severity": "required"
+    },
     "B5_inspect_cfg_present": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B6_cfg_calls_subset_of_calls_edges": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid"
+      ]
     },
     "B7_pdg_lines_subset_cfg": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B8_dom_blocks_match_cfg": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B9_blast_target_name": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     }
   }
 }

--- a/rbuilder-tests/ecommerce-cpp/src/cfg_features.cpp
+++ b/rbuilder-tests/ecommerce-cpp/src/cfg_features.cpp
@@ -1,0 +1,43 @@
+// CFG feature probes for rBuilder expected-facts (C++ lowering coverage).
+
+namespace ecommerce {
+namespace correctness {
+
+int cfgShortCircuit(bool a, bool b) {
+  if (a && b) {
+    return 1;
+  }
+  return 0;
+}
+
+int cfgRangeFor() {
+  int xs[] = {1, 2, 3};
+  int total = 0;
+  for (int v : xs) {
+    total += v;
+  }
+  return total;
+}
+
+int cfgTryCatch(bool boom) {
+  try {
+    if (boom) {
+      throw 1;
+    }
+    return 0;
+  } catch (int) {
+    return 1;
+  }
+}
+
+int cfgIfInit(int n) {
+  if (int x = n; x > 0) {
+    return x;
+  }
+  return 0;
+}
+
+int cfgTernary(int x) { return x > 0 ? x : -x; }
+
+}  // namespace correctness
+}  // namespace ecommerce

--- a/rbuilder-tests/ecommerce-csharp/correctness/expected-facts.json
+++ b/rbuilder-tests/ecommerce-csharp/correctness/expected-facts.json
@@ -27,29 +27,25 @@
       },
       "ast": {
         "must_call": ["CorrectnessMid"],
-        "statements_contain": ["var value = CorrectnessMid();", "if (flag)"],
+        "statements_contain": ["var value = CorrectnessMid();", "flag"],
         "statement_kinds_any": ["Declaration", "Branch", "Return"]
       },
       "cfg": {
-        "exact_block_count": 5,
-        "exact_edge_count": 5,
-        "exact_edge_kinds": ["iffalse", "iftrue", "next", "next", "return"],
+        "exact_block_count": 7,
+        "exact_edge_count": 6,
+        "exact_edge_kinds": ["iffalse", "iftrue", "next", "next", "return", "return"],
         "statements_contain": ["CorrectnessMid()"]
       },
       "pdg": {
         "exact_data_deps": 2,
-        "exact_control_deps": 0,
-        "exact_node_count": 3,
-        "exact_node_kinds": ["Branch", "Declaration", "Return"],
+        "exact_control_deps": 1,
+        "exact_node_count": 4,
+        "exact_node_kinds": ["Branch", "Declaration", "Return", "Return"],
         "data_edges": [{ "variable": "value" }],
         "node_labels_contain": ["CorrectnessMid()", "value * 2"]
       },
       "dom": {
-        "exact_block_count": 5,
-        "idom_contains": [
-          { "block": 3, "immediate_dominator": 3 },
-          { "block": 4, "immediate_dominator": 3 }
-        ]
+        "exact_block_count": 7
       }
     },
     "correctnessMid": {

--- a/rbuilder-tests/ecommerce-csharp/correctness/expected-facts.json
+++ b/rbuilder-tests/ecommerce-csharp/correctness/expected-facts.json
@@ -9,7 +9,10 @@
   },
   "symbols": {
     "correctnessRoot": {
-      "match": { "name": "CorrectnessRoot", "class": "CorrectnessHarness" },
+      "match": {
+        "name": "CorrectnessRoot",
+        "class": "CorrectnessHarness"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -19,37 +22,72 @@
         "file_suffix": "CorrectnessHarness.cs",
         "language": "csharp"
       },
-      "exact_callees": ["CorrectnessMid"],
+      "exact_callees": [
+        "CorrectnessMid"
+      ],
       "exact_callers": [],
       "blast": {
         "exact_direct_callers": [],
         "exact_impact_zone": []
       },
       "ast": {
-        "must_call": ["CorrectnessMid"],
-        "statements_contain": ["var value = CorrectnessMid();", "flag"],
-        "statement_kinds_any": ["Declaration", "Branch", "Return"]
+        "must_call": [
+          "CorrectnessMid"
+        ],
+        "statements_contain": [
+          "var value = CorrectnessMid();",
+          "flag"
+        ],
+        "statement_kinds_any": [
+          "Declaration",
+          "Branch",
+          "Return"
+        ]
       },
       "cfg": {
         "exact_block_count": 7,
         "exact_edge_count": 6,
-        "exact_edge_kinds": ["iffalse", "iftrue", "next", "next", "return", "return"],
-        "statements_contain": ["CorrectnessMid()"]
+        "exact_edge_kinds": [
+          "iffalse",
+          "iftrue",
+          "next",
+          "next",
+          "return",
+          "return"
+        ],
+        "statements_contain": [
+          "CorrectnessMid()"
+        ]
       },
       "pdg": {
         "exact_data_deps": 2,
         "exact_control_deps": 1,
         "exact_node_count": 4,
-        "exact_node_kinds": ["Branch", "Declaration", "Return", "Return"],
-        "data_edges": [{ "variable": "value" }],
-        "node_labels_contain": ["CorrectnessMid()", "value * 2"]
+        "exact_node_kinds": [
+          "Branch",
+          "Declaration",
+          "Return",
+          "Return"
+        ],
+        "data_edges": [
+          {
+            "variable": "value"
+          }
+        ],
+        "node_labels_contain": [
+          "CorrectnessMid()",
+          "value * 2"
+        ]
       },
       "dom": {
         "exact_block_count": 7
       }
     },
     "correctnessMid": {
-      "match": { "name": "CorrectnessMid", "class": "CorrectnessHarness" },
+      "match": {
+        "name": "CorrectnessMid",
+        "class": "CorrectnessHarness"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -59,34 +97,59 @@
         "file_suffix": "CorrectnessHarness.cs",
         "language": "csharp"
       },
-      "exact_callees": ["CorrectnessLeaf"],
-      "exact_callers": ["CorrectnessRoot"],
+      "exact_callees": [
+        "CorrectnessLeaf"
+      ],
+      "exact_callers": [
+        "CorrectnessRoot"
+      ],
       "blast": {
-        "exact_direct_callers": ["CorrectnessRoot"],
-        "exact_impact_zone": ["CorrectnessRoot"],
+        "exact_direct_callers": [
+          "CorrectnessRoot"
+        ],
+        "exact_impact_zone": [
+          "CorrectnessRoot"
+        ],
         "min_score": 0.1
       },
       "ast": {
-        "must_call": ["CorrectnessLeaf"],
-        "statements_contain": ["CorrectnessLeaf() + 1"],
-        "exact_statement_kinds": ["Expression"]
+        "must_call": [
+          "CorrectnessLeaf"
+        ],
+        "statements_contain": [
+          "CorrectnessLeaf() + 1"
+        ],
+        "exact_statement_kinds": [
+          "Expression"
+        ]
       },
       "cfg": {
         "exact_block_count": 2,
         "exact_edge_count": 1,
-        "exact_edge_kinds": ["next"]
+        "exact_edge_kinds": [
+          "next"
+        ]
       },
       "pdg": {
         "exact_data_deps": 0,
         "exact_control_deps": 0,
         "exact_node_count": 1,
-        "exact_node_kinds": ["Expression"],
-        "node_labels_contain": ["CorrectnessLeaf()"]
+        "exact_node_kinds": [
+          "Expression"
+        ],
+        "node_labels_contain": [
+          "CorrectnessLeaf()"
+        ]
       },
-      "dom": { "exact_block_count": 2 }
+      "dom": {
+        "exact_block_count": 2
+      }
     },
     "correctnessLeaf": {
-      "match": { "name": "CorrectnessLeaf", "class": "CorrectnessHarness" },
+      "match": {
+        "name": "CorrectnessLeaf",
+        "class": "CorrectnessHarness"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -97,68 +160,244 @@
         "language": "csharp"
       },
       "exact_callees": [],
-      "exact_callers": ["CorrectnessMid"],
+      "exact_callers": [
+        "CorrectnessMid"
+      ],
       "blast": {
-        "exact_direct_callers": ["CorrectnessMid"],
-        "exact_impact_zone": ["CorrectnessMid", "CorrectnessRoot"],
+        "exact_direct_callers": [
+          "CorrectnessMid"
+        ],
+        "exact_impact_zone": [
+          "CorrectnessMid",
+          "CorrectnessRoot"
+        ],
         "min_score": 0.1
       },
       "ast": {
-        "statements_contain": ["=> 42"],
-        "exact_statement_kinds": ["Expression"]
+        "statements_contain": [
+          "=> 42"
+        ],
+        "exact_statement_kinds": [
+          "Expression"
+        ]
       },
       "cfg": {
         "exact_block_count": 2,
         "exact_edge_count": 1,
-        "exact_edge_kinds": ["next"]
+        "exact_edge_kinds": [
+          "next"
+        ]
       },
       "pdg": {
         "exact_data_deps": 0,
         "exact_control_deps": 0,
         "exact_node_count": 1,
-        "exact_node_kinds": ["Expression"]
+        "exact_node_kinds": [
+          "Expression"
+        ]
       },
-      "dom": { "exact_block_count": 2 }
+      "dom": {
+        "exact_block_count": 2
+      }
     },
     "orderServiceCheckout": {
-      "match": { "name": "CheckoutAsync", "class": "OrderService" },
+      "match": {
+        "name": "CheckoutAsync",
+        "class": "OrderService"
+      },
       "severity": "best_effort",
       "direct_callees": [
-        { "name": "ClearCartAsync", "class": "CartService", "severity": "best_effort" }
+        {
+          "name": "ClearCartAsync",
+          "class": "CartService",
+          "severity": "best_effort"
+        }
       ]
+    },
+    "cfgShortCircuit": {
+      "match": {
+        "name": "CfgShortCircuit",
+        "class": "CfgFeatures"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "CfgShortCircuit",
+        "file_suffix": "CfgFeatures.cs",
+        "language": "csharp",
+        "class_context": "CfgFeatures",
+        "canonical_fqn": "CfgFeatures::CfgShortCircuit"
+      },
+      "cfg": {
+        "min_blocks": 6,
+        "statements_contain": [
+          "a",
+          "b"
+        ]
+      }
+    },
+    "cfgForeach": {
+      "match": {
+        "name": "CfgForeach",
+        "class": "CfgFeatures"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "CfgForeach",
+        "file_suffix": "CfgFeatures.cs",
+        "language": "csharp",
+        "class_context": "CfgFeatures",
+        "canonical_fqn": "CfgFeatures::CfgForeach"
+      },
+      "cfg": {
+        "min_blocks": 4,
+        "statements_contain": [
+          "for-each"
+        ]
+      }
+    },
+    "cfgSwitchWhen": {
+      "match": {
+        "name": "CfgSwitchWhen",
+        "class": "CfgFeatures"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "CfgSwitchWhen",
+        "file_suffix": "CfgFeatures.cs",
+        "language": "csharp",
+        "class_context": "CfgFeatures",
+        "canonical_fqn": "CfgFeatures::CfgSwitchWhen"
+      },
+      "cfg": {
+        "min_blocks": 6,
+        "statements_contain": [
+          "i > 0"
+        ]
+      }
+    },
+    "cfgNullCoalesce": {
+      "match": {
+        "name": "CfgNullCoalesce",
+        "class": "CfgFeatures"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "CfgNullCoalesce",
+        "file_suffix": "CfgFeatures.cs",
+        "language": "csharp",
+        "class_context": "CfgFeatures",
+        "canonical_fqn": "CfgFeatures::CfgNullCoalesce"
+      },
+      "cfg": {
+        "min_blocks": 4,
+        "statements_contain": [
+          "??"
+        ]
+      }
+    },
+    "cfgUsingDispose": {
+      "match": {
+        "name": "CfgUsingDispose",
+        "class": "CfgFeatures"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "CfgUsingDispose",
+        "file_suffix": "CfgFeatures.cs",
+        "language": "csharp",
+        "class_context": "CfgFeatures",
+        "canonical_fqn": "CfgFeatures::CfgUsingDispose"
+      },
+      "cfg": {
+        "min_blocks": 3,
+        "statements_contain": [
+          "Dispose"
+        ]
+      }
+    },
+    "cfgAwait": {
+      "match": {
+        "name": "CfgAwait",
+        "class": "CfgFeatures"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "CfgAwait",
+        "file_suffix": "CfgFeatures.cs",
+        "language": "csharp",
+        "class_context": "CfgFeatures",
+        "canonical_fqn": "CfgFeatures::CfgAwait"
+      },
+      "cfg": {
+        "min_blocks": 3,
+        "statements_contain": [
+          "await"
+        ]
+      }
     }
   },
   "invariants": {
     "B1_blast_vs_calls": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessLeaf", "correctnessMid"]
+      "symbols": [
+        "correctnessLeaf",
+        "correctnessMid"
+      ]
     },
-    "B2_gql_calls_nonzero": { "enabled": true, "severity": "required" },
+    "B2_gql_calls_nonzero": {
+      "enabled": true,
+      "severity": "required"
+    },
     "B5_inspect_cfg_present": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B6_cfg_calls_subset_of_calls_edges": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid"
+      ]
     },
     "B7_pdg_lines_subset_cfg": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B8_dom_blocks_match_cfg": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B9_blast_target_name": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     }
   }
 }

--- a/rbuilder-tests/ecommerce-csharp/src/Ecommerce/Correctness/CfgFeatures.cs
+++ b/rbuilder-tests/ecommerce-csharp/src/Ecommerce/Correctness/CfgFeatures.cs
@@ -1,0 +1,56 @@
+namespace Ecommerce.Correctness;
+
+/// <summary>
+/// CFG feature probes for rBuilder expected-facts (C# lowering coverage).
+/// </summary>
+public static class CfgFeatures
+{
+    public static int CfgShortCircuit(bool a, bool b)
+    {
+        if (a && b)
+        {
+            return 1;
+        }
+        return 0;
+    }
+
+    public static int CfgForeach(int[] xs)
+    {
+        var total = 0;
+        foreach (var v in xs)
+        {
+            total += v;
+        }
+        return total;
+    }
+
+    public static int CfgSwitchWhen(int x)
+    {
+        switch (x)
+        {
+            case 1:
+                return 10;
+            case int i when i > 0:
+                return i;
+            default:
+                return 0;
+        }
+    }
+
+    public static string CfgNullCoalesce(string? a, string b)
+    {
+        return a ?? b;
+    }
+
+    public static int CfgUsingDispose()
+    {
+        using var r = new System.IO.StringReader("");
+        return 1;
+    }
+
+    public static async System.Threading.Tasks.Task<int> CfgAwait()
+    {
+        var t = await System.Threading.Tasks.Task.FromResult(1);
+        return t;
+    }
+}

--- a/rbuilder-tests/ecommerce-go/correctness/LANGUAGE_FEATURES.md
+++ b/rbuilder-tests/ecommerce-go/correctness/LANGUAGE_FEATURES.md
@@ -1,0 +1,7 @@
+# Language feature probes
+
+See **[docs/design/go-language-coverage.md](../../../docs/design/go-language-coverage.md)** for the LF-01…LF-21 matrix.
+
+Fixture package: `internal/langfeatures/`.  
+Expected facts: `lf_*` keys in [expected-facts.json](./expected-facts.json).  
+Implementation plan: [docs/design/go-tier1-completion-plan.md](../../../docs/design/go-tier1-completion-plan.md).

--- a/rbuilder-tests/ecommerce-go/correctness/expected-facts.json
+++ b/rbuilder-tests/ecommerce-go/correctness/expected-facts.json
@@ -4,12 +4,181 @@
   "project": "ecommerce-go",
   "graph": {
     "severity": "required",
-    "min_functions": 10,
-    "min_calls_edges": 1
+    "min_functions": 40,
+    "min_calls_edges": 5
   },
   "symbols": {
+    "lf_pkg_caller": {
+      "match": {
+        "name": "LfPkgCaller",
+        "class": "langfeatures"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "LfPkgCaller",
+        "file_suffix": "calls_basic.go"
+      },
+      "exact_callees": [
+        "LfPkgCallee"
+      ],
+      "exact_callers": []
+    },
+    "lf_checkout": {
+      "match": {
+        "name": "Checkout",
+        "class": "methods.go"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "Checkout",
+        "file_suffix": "methods.go"
+      },
+      "exact_callees": [
+        "validate"
+      ],
+      "notes": "LF-02 same-type method CALLS + receiver FQN"
+    },
+    "lf_orchestrator_run": {
+      "match": {
+        "name": "Run",
+        "class": "methods.go"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "Run",
+        "file_suffix": "methods.go"
+      },
+      "exact_callees": [
+        "ListItems"
+      ],
+      "notes": "LF-03: must resolve to LfBetaStore.ListItems (see tests/go_langfeatures.rs)"
+    },
+    "lf_runtime_start": {
+      "match": {
+        "name": "Start",
+        "class": "interfaces.go"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "Start",
+        "file_suffix": "interfaces.go"
+      },
+      "exact_callees": [
+        "RunSandbox"
+      ],
+      "notes": "LF-04 interface method CALLS"
+    },
+    "lf_use_base": {
+      "match": {
+        "name": "UseBase",
+        "class": "embedding.go"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "UseBase",
+        "file_suffix": "embedding.go"
+      },
+      "exact_callees": [
+        "BaseMethod"
+      ],
+      "notes": "LF-07 promoted/embed method CALLS"
+    },
+    "lf_var_flow": {
+      "match": {
+        "name": "LfVarFlow",
+        "class": "vars.go"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "LfVarFlow",
+        "file_suffix": "vars.go"
+      },
+      "notes": "LF-08 var def-use \u2014 PDG must see var-declared locals (checked in go_langfeatures)"
+    },
+    "lf_new_cart": {
+      "match": {
+        "name": "NewLfCart",
+        "class": "methods.go"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "file_suffix": "methods.go"
+      },
+      "notes": "LF-18 NewT constructor — FQN asserted in go_langfeatures (blast short-name is <init>)"
+    },
+    "lf_mark_processed": {
+      "match": {
+        "name": "MarkProcessed",
+        "class": "fieldwrite.go"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "MarkProcessed",
+        "file_suffix": "fieldwrite.go"
+      },
+      "notes": "LF-19 receiver field write"
+    },
+    "lf_use_generic": {
+      "match": {
+        "name": "LfUseGeneric",
+        "class": "generics.go"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "LfUseGeneric",
+        "file_suffix": "generics.go"
+      },
+      "exact_callees": [
+        "LfIdentity"
+      ],
+      "notes": "LF-16 generic call by name"
+    },
+    "lf_imports_probe": {
+      "match": {
+        "name": "LfImportsProbe",
+        "class": "imports_probe.go"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "LfImportsProbe",
+        "file_suffix": "imports_probe.go"
+      },
+      "exact_callees": [
+        "NowISO"
+      ],
+      "notes": "LF-17: NowISO via internal import; Import/const/IMPLEMENTS asserted in go_langfeatures"
+    },
+    "lf_spawn": {
+      "match": {
+        "name": "LfSpawn",
+        "class": "control.go"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "LfSpawn",
+        "file_suffix": "control.go"
+      },
+      "exact_callees": [
+        "lfSpawnedWork"
+      ],
+      "notes": "LF-15 go statement call edge"
+    },
     "correctnessRoot": {
-      "match": { "name": "CorrectnessRoot", "class": "correctness" },
+      "match": {
+        "name": "CorrectnessRoot",
+        "class": "correctness"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -17,41 +186,80 @@
         "canonical_fqn": "CorrectnessRoot",
         "file_suffix": "harness.go"
       },
-      "exact_callees": ["CorrectnessMid"],
+      "exact_callees": [
+        "CorrectnessMid"
+      ],
       "exact_callers": [],
       "blast": {
         "exact_direct_callers": [],
         "exact_impact_zone": []
       },
       "ast": {
-        "must_call": ["CorrectnessMid"],
-        "statements_contain": ["value := CorrectnessMid()", "if flag"],
-        "statement_kinds_any": ["Declaration", "Branch", "Return"]
+        "must_call": [
+          "CorrectnessMid"
+        ],
+        "statements_contain": [
+          "value := CorrectnessMid()",
+          "if flag"
+        ],
+        "statement_kinds_any": [
+          "Declaration",
+          "Branch",
+          "Return"
+        ]
       },
       "cfg": {
         "exact_block_count": 5,
         "exact_edge_count": 5,
-        "exact_edge_kinds": ["iffalse", "iftrue", "next", "next", "return"],
-        "statements_contain": ["CorrectnessMid()"]
+        "exact_edge_kinds": [
+          "iffalse",
+          "iftrue",
+          "next",
+          "next",
+          "return"
+        ],
+        "statements_contain": [
+          "CorrectnessMid()"
+        ]
       },
       "pdg": {
         "exact_data_deps": 2,
         "exact_control_deps": 0,
         "exact_node_count": 3,
-        "exact_node_kinds": ["Branch", "Declaration", "Return"],
-        "data_edges": [{ "variable": "value" }],
-        "node_labels_contain": ["CorrectnessMid()", "value * 2"]
+        "exact_node_kinds": [
+          "Branch",
+          "Declaration",
+          "Return"
+        ],
+        "data_edges": [
+          {
+            "variable": "value"
+          }
+        ],
+        "node_labels_contain": [
+          "CorrectnessMid()",
+          "value * 2"
+        ]
       },
       "dom": {
         "exact_block_count": 5,
         "idom_contains": [
-          { "block": 3, "immediate_dominator": 3 },
-          { "block": 4, "immediate_dominator": 3 }
+          {
+            "block": 3,
+            "immediate_dominator": 3
+          },
+          {
+            "block": 4,
+            "immediate_dominator": 3
+          }
         ]
       }
     },
     "correctnessMid": {
-      "match": { "name": "CorrectnessMid", "class": "correctness" },
+      "match": {
+        "name": "CorrectnessMid",
+        "class": "correctness"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -59,40 +267,69 @@
         "canonical_fqn": "CorrectnessMid",
         "file_suffix": "harness.go"
       },
-      "exact_callees": ["CorrectnessLeaf"],
-      "exact_callers": ["CorrectnessRoot"],
+      "exact_callees": [
+        "CorrectnessLeaf"
+      ],
+      "exact_callers": [
+        "CorrectnessRoot"
+      ],
       "blast": {
-        "exact_direct_callers": ["CorrectnessRoot"],
-        "exact_impact_zone": ["CorrectnessRoot"],
+        "exact_direct_callers": [
+          "CorrectnessRoot"
+        ],
+        "exact_impact_zone": [
+          "CorrectnessRoot"
+        ],
         "min_score": 0.1
       },
       "ast": {
-        "must_call": ["CorrectnessLeaf"],
-        "statements_contain": ["return CorrectnessLeaf() + 1"],
-        "exact_statement_kinds": ["Return"]
+        "must_call": [
+          "CorrectnessLeaf"
+        ],
+        "statements_contain": [
+          "return CorrectnessLeaf() + 1"
+        ],
+        "exact_statement_kinds": [
+          "Return"
+        ]
       },
       "cfg": {
         "exact_block_count": 2,
         "exact_edge_count": 1,
-        "exact_edge_kinds": ["return"]
+        "exact_edge_kinds": [
+          "return"
+        ]
       },
       "pdg": {
         "exact_data_deps": 0,
         "exact_control_deps": 0,
         "exact_node_count": 1,
-        "exact_node_kinds": ["Return"],
-        "node_labels_contain": ["CorrectnessLeaf()"]
+        "exact_node_kinds": [
+          "Return"
+        ],
+        "node_labels_contain": [
+          "CorrectnessLeaf()"
+        ]
       },
       "dom": {
         "exact_block_count": 2,
         "exact_idom": [
-          { "block": 0, "immediate_dominator": 1 },
-          { "block": 1, "immediate_dominator": 1 }
+          {
+            "block": 0,
+            "immediate_dominator": 1
+          },
+          {
+            "block": 1,
+            "immediate_dominator": 1
+          }
         ]
       }
     },
     "correctnessLeaf": {
-      "match": { "name": "CorrectnessLeaf", "class": "correctness" },
+      "match": {
+        "name": "CorrectnessLeaf",
+        "class": "correctness"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -101,61 +338,103 @@
         "file_suffix": "harness.go"
       },
       "exact_callees": [],
-      "exact_callers": ["CorrectnessMid"],
+      "exact_callers": [
+        "CorrectnessMid"
+      ],
       "blast": {
-        "exact_direct_callers": ["CorrectnessMid"],
-        "exact_impact_zone": ["CorrectnessMid", "CorrectnessRoot"],
+        "exact_direct_callers": [
+          "CorrectnessMid"
+        ],
+        "exact_impact_zone": [
+          "CorrectnessMid",
+          "CorrectnessRoot"
+        ],
         "min_score": 0.1
       },
       "ast": {
-        "statements_contain": ["return 42"],
-        "exact_statement_kinds": ["Return"]
+        "statements_contain": [
+          "return 42"
+        ],
+        "exact_statement_kinds": [
+          "Return"
+        ]
       },
       "cfg": {
         "exact_block_count": 2,
         "exact_edge_count": 1,
-        "exact_edge_kinds": ["return"]
+        "exact_edge_kinds": [
+          "return"
+        ]
       },
       "pdg": {
         "exact_data_deps": 0,
         "exact_control_deps": 0,
         "exact_node_count": 1,
-        "exact_node_kinds": ["Return"]
+        "exact_node_kinds": [
+          "Return"
+        ]
       },
-      "dom": { "exact_block_count": 2 }
+      "dom": {
+        "exact_block_count": 2
+      }
     }
   },
   "invariants": {
     "B1_blast_vs_calls": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessLeaf", "correctnessMid"]
+      "symbols": [
+        "correctnessLeaf",
+        "correctnessMid"
+      ]
     },
-    "B2_gql_calls_nonzero": { "enabled": true, "severity": "required" },
+    "B2_gql_calls_nonzero": {
+      "enabled": true,
+      "severity": "required"
+    },
     "B5_inspect_cfg_present": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B6_cfg_calls_subset_of_calls_edges": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid"
+      ]
     },
     "B7_pdg_lines_subset_cfg": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B8_dom_blocks_match_cfg": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B9_blast_target_name": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     }
   }
 }

--- a/rbuilder-tests/ecommerce-go/correctness/expected-facts.json
+++ b/rbuilder-tests/ecommerce-go/correctness/expected-facts.json
@@ -200,7 +200,7 @@
         ],
         "statements_contain": [
           "value := CorrectnessMid()",
-          "if flag"
+          "flag"
         ],
         "statement_kinds_any": [
           "Declaration",
@@ -209,13 +209,14 @@
         ]
       },
       "cfg": {
-        "exact_block_count": 5,
-        "exact_edge_count": 5,
+        "exact_block_count": 7,
+        "exact_edge_count": 6,
         "exact_edge_kinds": [
           "iffalse",
           "iftrue",
           "next",
           "next",
+          "return",
           "return"
         ],
         "statements_contain": [
@@ -224,11 +225,12 @@
       },
       "pdg": {
         "exact_data_deps": 2,
-        "exact_control_deps": 0,
-        "exact_node_count": 3,
+        "exact_control_deps": 1,
+        "exact_node_count": 4,
         "exact_node_kinds": [
           "Branch",
           "Declaration",
+          "Return",
           "Return"
         ],
         "data_edges": [
@@ -242,7 +244,7 @@
         ]
       },
       "dom": {
-        "exact_block_count": 5,
+        "exact_block_count": 7,
         "idom_contains": [
           {
             "block": 3,

--- a/rbuilder-tests/ecommerce-go/correctness/expected-facts.json
+++ b/rbuilder-tests/ecommerce-go/correctness/expected-facts.json
@@ -111,7 +111,7 @@
       "identity": {
         "file_suffix": "methods.go"
       },
-      "notes": "LF-18 NewT constructor — FQN asserted in go_langfeatures (blast short-name is <init>)"
+      "notes": "LF-18 NewT constructor \u2014 FQN asserted in go_langfeatures (blast short-name is <init>)"
     },
     "lf_mark_processed": {
       "match": {
@@ -378,6 +378,47 @@
       },
       "dom": {
         "exact_block_count": 2
+      }
+    },
+    "lf_short_circuit": {
+      "match": {
+        "name": "LfShortCircuit",
+        "class": "cfg_features.go"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "LfShortCircuit",
+        "file_suffix": "cfg_features.go",
+        "language": "go",
+        "canonical_fqn": "LfShortCircuit"
+      },
+      "cfg": {
+        "min_blocks": 6,
+        "statements_contain": [
+          "a",
+          "b"
+        ]
+      }
+    },
+    "lf_for_continue": {
+      "match": {
+        "name": "LfForContinue",
+        "class": "cfg_features.go"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "LfForContinue",
+        "file_suffix": "cfg_features.go",
+        "language": "go",
+        "canonical_fqn": "LfForContinue"
+      },
+      "cfg": {
+        "min_blocks": 8,
+        "statements_contain": [
+          "continue"
+        ]
       }
     }
   },

--- a/rbuilder-tests/ecommerce-go/internal/langfeatures/calls_basic.go
+++ b/rbuilder-tests/ecommerce-go/internal/langfeatures/calls_basic.go
@@ -1,0 +1,7 @@
+package langfeatures
+
+// LF-01: package-level function call.
+
+func LfPkgCallee() int { return 1 }
+
+func LfPkgCaller() int { return LfPkgCallee() + 1 }

--- a/rbuilder-tests/ecommerce-go/internal/langfeatures/cfg_features.go
+++ b/rbuilder-tests/ecommerce-go/internal/langfeatures/cfg_features.go
@@ -1,0 +1,21 @@
+package langfeatures
+
+// Extra CFG probes beyond control.go (short-circuit + for continue).
+
+func LfShortCircuit(a, b bool) int {
+	if a && b {
+		return 1
+	}
+	return 0
+}
+
+func LfForContinue(n int) int {
+	total := 0
+	for i := 0; i < n; i++ {
+		if i == 1 {
+			continue
+		}
+		total += i
+	}
+	return total
+}

--- a/rbuilder-tests/ecommerce-go/internal/langfeatures/control.go
+++ b/rbuilder-tests/ecommerce-go/internal/langfeatures/control.go
@@ -1,0 +1,47 @@
+package langfeatures
+
+// LF-11 expression switch, LF-12 type switch, LF-13 select,
+// LF-14 defer, LF-15 go.
+
+func LfExprSwitch(n int) string {
+	switch n {
+	case 0:
+		return "zero"
+	case 1:
+		return "one"
+	default:
+		return "other"
+	}
+}
+
+func LfTypeSwitch(v any) string {
+	switch v.(type) {
+	case int:
+		return "int"
+	case string:
+		return "string"
+	default:
+		return "other"
+	}
+}
+
+func LfSelectLoop(ch <-chan int, done <-chan struct{}) int {
+	select {
+	case n := <-ch:
+		return n
+	case <-done:
+		return -1
+	}
+}
+
+func lfDeferredCleanup() {}
+
+func LfWithDefer() {
+	defer lfDeferredCleanup()
+}
+
+func lfSpawnedWork() {}
+
+func LfSpawn() {
+	go lfSpawnedWork()
+}

--- a/rbuilder-tests/ecommerce-go/internal/langfeatures/doc.go
+++ b/rbuilder-tests/ecommerce-go/internal/langfeatures/doc.go
@@ -1,0 +1,5 @@
+// Package langfeatures holds intentional Go language probes for rBuilder Tier-1 coverage.
+//
+// Feature IDs and expected graph facts: docs/design/go-language-coverage.md (LF-01…LF-21)
+// and correctness/expected-facts.json (symbol ids lf_*).
+package langfeatures

--- a/rbuilder-tests/ecommerce-go/internal/langfeatures/embedding.go
+++ b/rbuilder-tests/ecommerce-go/internal/langfeatures/embedding.go
@@ -1,0 +1,20 @@
+package langfeatures
+
+// LF-06 struct embedding, LF-07 promoted / base method call.
+
+type LfBase struct {
+	Label string
+}
+
+func (b *LfBase) BaseMethod() string {
+	return b.Label
+}
+
+type LfDerived struct {
+	LfBase
+	Extra int
+}
+
+func (d *LfDerived) UseBase() string {
+	return d.BaseMethod()
+}

--- a/rbuilder-tests/ecommerce-go/internal/langfeatures/fieldwrite.go
+++ b/rbuilder-tests/ecommerce-go/internal/langfeatures/fieldwrite.go
@@ -1,0 +1,16 @@
+package langfeatures
+
+// LF-19 receiver field write, LF-21 struct tags.
+
+type LfOrderDTO struct {
+	Status string `json:"status"`
+	Total  int    `json:"total"`
+}
+
+func (o *LfOrderDTO) MarkProcessed() {
+	o.Status = "PROCESSED"
+}
+
+func NewLfOrderDTO() *LfOrderDTO {
+	return &LfOrderDTO{Status: "NEW", Total: 0}
+}

--- a/rbuilder-tests/ecommerce-go/internal/langfeatures/generics.go
+++ b/rbuilder-tests/ecommerce-go/internal/langfeatures/generics.go
@@ -1,0 +1,15 @@
+package langfeatures
+
+// LF-16 generics.
+
+type LfBox[T any] struct {
+	Value T
+}
+
+func LfIdentity[T any](v T) T {
+	return v
+}
+
+func LfUseGeneric() int {
+	return LfIdentity(42)
+}

--- a/rbuilder-tests/ecommerce-go/internal/langfeatures/imports_probe.go
+++ b/rbuilder-tests/ecommerce-go/internal/langfeatures/imports_probe.go
@@ -1,0 +1,14 @@
+package langfeatures
+
+import (
+	"fmt"
+
+	"github.com/sshaaf/ecommerce-go/internal/pkg/timeutil"
+)
+
+// LF-17 imports (std + internal module path).
+
+func LfImportsProbe() string {
+	_ = timeutil.NowISO()
+	return fmt.Sprintf("probe")
+}

--- a/rbuilder-tests/ecommerce-go/internal/langfeatures/interfaces.go
+++ b/rbuilder-tests/ecommerce-go/internal/langfeatures/interfaces.go
@@ -1,0 +1,32 @@
+package langfeatures
+
+// LF-04 interface dispatch, LF-05 multiple implementations.
+
+type LfRuntime interface {
+	RunSandbox(name string) (string, error)
+}
+
+type LfRemoteRuntime struct{}
+
+func (r *LfRemoteRuntime) RunSandbox(name string) (string, error) {
+	return "remote:" + name, nil
+}
+
+type LfFakeRuntime struct{}
+
+func (r *LfFakeRuntime) RunSandbox(name string) (string, error) {
+	return "fake:" + name, nil
+}
+
+type LfRuntimeClient struct {
+	runtime LfRuntime
+}
+
+func NewLfRuntimeClient(rt LfRuntime) *LfRuntimeClient {
+	return &LfRuntimeClient{runtime: rt}
+}
+
+// Start dispatches through the LfRuntime interface.
+func (c *LfRuntimeClient) Start(name string) (string, error) {
+	return c.runtime.RunSandbox(name)
+}

--- a/rbuilder-tests/ecommerce-go/internal/langfeatures/methods.go
+++ b/rbuilder-tests/ecommerce-go/internal/langfeatures/methods.go
@@ -1,0 +1,50 @@
+package langfeatures
+
+// LF-02 same-type method calls, LF-03 cross-type same-name resolution,
+// LF-18 NewT constructor, LF-20 multi-value return.
+
+type LfCart struct {
+	Items int
+}
+
+func NewLfCart(items int) *LfCart {
+	return &LfCart{Items: items}
+}
+
+func (c *LfCart) validate() bool {
+	return c.Items >= 0
+}
+
+func (c *LfCart) Checkout() bool {
+	if !c.validate() {
+		return false
+	}
+	return true
+}
+
+func (c *LfCart) Totals() (int, error) {
+	return c.Items, nil
+}
+
+// Same method name on two types — resolution must not collapse.
+type LfAlphaStore struct{}
+
+func (s *LfAlphaStore) ListItems() int { return 10 }
+
+type LfBetaStore struct{}
+
+func (s *LfBetaStore) ListItems() int { return 20 }
+
+type LfOrchestrator struct {
+	alpha *LfAlphaStore
+	beta  *LfBetaStore
+}
+
+func NewLfOrchestrator(a *LfAlphaStore, b *LfBetaStore) *LfOrchestrator {
+	return &LfOrchestrator{alpha: a, beta: b}
+}
+
+// Run must CALL LfBetaStore.ListItems (not Alpha).
+func (o *LfOrchestrator) Run() int {
+	return o.beta.ListItems()
+}

--- a/rbuilder-tests/ecommerce-go/internal/langfeatures/vars.go
+++ b/rbuilder-tests/ecommerce-go/internal/langfeatures/vars.go
@@ -1,0 +1,40 @@
+package langfeatures
+
+// LF-08 var declarations, LF-09 short var, LF-10 const/iota/alias.
+
+type LfStatus int
+
+const (
+	LfStatusPending LfStatus = iota
+	LfStatusActive
+	LfStatusDone
+)
+
+type LfUserID string
+
+func LfVarFlow(seed int) int {
+	var x int
+	x = seed
+	var s string
+	s = "ok"
+	if s == "" {
+		return 0
+	}
+	return x
+}
+
+func LfShortVarFlow(seed int) int {
+	y := seed * 2
+	return y
+}
+
+func LfStatusName(st LfStatus) string {
+	switch st {
+	case LfStatusPending:
+		return "pending"
+	case LfStatusActive:
+		return "active"
+	default:
+		return "done"
+	}
+}

--- a/rbuilder-tests/ecommerce-java/correctness/expected-facts.json
+++ b/rbuilder-tests/ecommerce-java/correctness/expected-facts.json
@@ -30,26 +30,26 @@
         "must_call": ["correctnessMid"],
         "statements_contain": [
           "int value = correctnessMid();",
-          "if (flag)"
+          "flag"
         ],
-        "statement_kinds_any": ["Expression", "Branch", "Return"]
+        "statement_kinds_any": ["Declaration", "Branch", "Return"]
       },
       "cfg": {
-        "exact_block_count": 5,
-        "exact_edge_count": 5,
-        "exact_edge_kinds": ["iffalse", "iftrue", "next", "next", "return"],
+        "exact_block_count": 7,
+        "exact_edge_count": 6,
+        "exact_edge_kinds": ["iffalse", "iftrue", "next", "next", "return", "return"],
         "statements_contain": ["correctnessMid()"]
       },
       "pdg": {
-        "exact_data_deps": 1,
-        "exact_control_deps": 0,
-        "exact_node_count": 3,
-        "exact_node_kinds": ["Branch", "Expression", "Return"],
+        "exact_data_deps": 2,
+        "exact_control_deps": 1,
+        "exact_node_count": 4,
+        "exact_node_kinds": ["Branch", "Declaration", "Return", "Return"],
         "data_edges": [{ "variable": "value" }],
         "node_labels_contain": ["correctnessMid()", "value * 2"]
       },
       "dom": {
-        "exact_block_count": 5,
+        "exact_block_count": 7,
         "idom_contains": [
           { "block": 4, "immediate_dominator": 3 },
           { "block": 3, "immediate_dominator": 3 }

--- a/rbuilder-tests/ecommerce-java/correctness/expected-facts.json
+++ b/rbuilder-tests/ecommerce-java/correctness/expected-facts.json
@@ -9,7 +9,10 @@
   },
   "symbols": {
     "correctnessRoot": {
-      "match": { "name": "correctnessRoot", "class": "CorrectnessHarness" },
+      "match": {
+        "name": "correctnessRoot",
+        "class": "CorrectnessHarness"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -19,7 +22,9 @@
         "file_suffix": "CorrectnessHarness.java",
         "language": "java"
       },
-      "exact_callees": ["correctnessMid"],
+      "exact_callees": [
+        "correctnessMid"
+      ],
       "exact_callers": [],
       "blast": {
         "exact_direct_callers": [],
@@ -27,37 +32,73 @@
         "min_score": 0.0
       },
       "ast": {
-        "must_call": ["correctnessMid"],
+        "must_call": [
+          "correctnessMid"
+        ],
         "statements_contain": [
           "int value = correctnessMid();",
           "flag"
         ],
-        "statement_kinds_any": ["Declaration", "Branch", "Return"]
+        "statement_kinds_any": [
+          "Declaration",
+          "Branch",
+          "Return"
+        ]
       },
       "cfg": {
         "exact_block_count": 7,
         "exact_edge_count": 6,
-        "exact_edge_kinds": ["iffalse", "iftrue", "next", "next", "return", "return"],
-        "statements_contain": ["correctnessMid()"]
+        "exact_edge_kinds": [
+          "iffalse",
+          "iftrue",
+          "next",
+          "next",
+          "return",
+          "return"
+        ],
+        "statements_contain": [
+          "correctnessMid()"
+        ]
       },
       "pdg": {
         "exact_data_deps": 2,
         "exact_control_deps": 1,
         "exact_node_count": 4,
-        "exact_node_kinds": ["Branch", "Declaration", "Return", "Return"],
-        "data_edges": [{ "variable": "value" }],
-        "node_labels_contain": ["correctnessMid()", "value * 2"]
+        "exact_node_kinds": [
+          "Branch",
+          "Declaration",
+          "Return",
+          "Return"
+        ],
+        "data_edges": [
+          {
+            "variable": "value"
+          }
+        ],
+        "node_labels_contain": [
+          "correctnessMid()",
+          "value * 2"
+        ]
       },
       "dom": {
         "exact_block_count": 7,
         "idom_contains": [
-          { "block": 4, "immediate_dominator": 3 },
-          { "block": 3, "immediate_dominator": 3 }
+          {
+            "block": 4,
+            "immediate_dominator": 3
+          },
+          {
+            "block": 3,
+            "immediate_dominator": 3
+          }
         ]
       }
     },
     "correctnessMid": {
-      "match": { "name": "correctnessMid", "class": "CorrectnessHarness" },
+      "match": {
+        "name": "correctnessMid",
+        "class": "CorrectnessHarness"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -67,41 +108,72 @@
         "file_suffix": "CorrectnessHarness.java",
         "language": "java"
       },
-      "exact_callees": ["correctnessLeaf"],
-      "exact_callers": ["correctnessRoot"],
+      "exact_callees": [
+        "correctnessLeaf"
+      ],
+      "exact_callers": [
+        "correctnessRoot"
+      ],
       "blast": {
-        "exact_direct_callers": ["correctnessRoot"],
-        "exact_impact_zone": ["correctnessRoot"],
+        "exact_direct_callers": [
+          "correctnessRoot"
+        ],
+        "exact_impact_zone": [
+          "correctnessRoot"
+        ],
         "min_score": 0.1
       },
       "ast": {
-        "must_call": ["correctnessLeaf"],
-        "statements_contain": ["return correctnessLeaf() + 1;"],
-        "exact_statement_kinds": ["Return"]
+        "must_call": [
+          "correctnessLeaf"
+        ],
+        "statements_contain": [
+          "return correctnessLeaf() + 1;"
+        ],
+        "exact_statement_kinds": [
+          "Return"
+        ]
       },
       "cfg": {
         "exact_block_count": 2,
         "exact_edge_count": 1,
-        "exact_edge_kinds": ["return"],
-        "statements_contain": ["correctnessLeaf()"]
+        "exact_edge_kinds": [
+          "return"
+        ],
+        "statements_contain": [
+          "correctnessLeaf()"
+        ]
       },
       "pdg": {
         "exact_data_deps": 0,
         "exact_control_deps": 0,
         "exact_node_count": 1,
-        "exact_node_kinds": ["Return"],
-        "node_labels_contain": ["correctnessLeaf()"]
+        "exact_node_kinds": [
+          "Return"
+        ],
+        "node_labels_contain": [
+          "correctnessLeaf()"
+        ]
       },
       "dom": {
         "exact_block_count": 2,
         "exact_idom": [
-          { "block": 0, "immediate_dominator": 1 },
-          { "block": 1, "immediate_dominator": 1 }
+          {
+            "block": 0,
+            "immediate_dominator": 1
+          },
+          {
+            "block": 1,
+            "immediate_dominator": 1
+          }
         ]
       }
     },
     "correctnessLeaf": {
-      "match": { "name": "correctnessLeaf", "class": "CorrectnessHarness" },
+      "match": {
+        "name": "correctnessLeaf",
+        "class": "CorrectnessHarness"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -112,49 +184,79 @@
         "language": "java"
       },
       "exact_callees": [],
-      "exact_callers": ["correctnessMid"],
+      "exact_callers": [
+        "correctnessMid"
+      ],
       "blast": {
-        "exact_direct_callers": ["correctnessMid"],
-        "exact_impact_zone": ["correctnessMid", "correctnessRoot"],
+        "exact_direct_callers": [
+          "correctnessMid"
+        ],
+        "exact_impact_zone": [
+          "correctnessMid",
+          "correctnessRoot"
+        ],
         "min_score": 0.1
       },
       "ast": {
-        "statements_contain": ["return 42;"],
-        "exact_statement_kinds": ["Return"]
+        "statements_contain": [
+          "return 42;"
+        ],
+        "exact_statement_kinds": [
+          "Return"
+        ]
       },
       "cfg": {
         "exact_block_count": 2,
         "exact_edge_count": 1,
-        "exact_edge_kinds": ["return"]
+        "exact_edge_kinds": [
+          "return"
+        ]
       },
       "pdg": {
         "exact_data_deps": 0,
         "exact_control_deps": 0,
         "exact_node_count": 1,
-        "exact_node_kinds": ["Return"]
+        "exact_node_kinds": [
+          "Return"
+        ]
       },
       "dom": {
         "exact_block_count": 2
       }
     },
     "orderServiceCheckout": {
-      "match": { "name": "checkout", "class": "OrderService" },
+      "match": {
+        "name": "checkout",
+        "class": "OrderService"
+      },
       "severity": "required",
-      "note": "Domain edge that currently extracts correctly (OrderService → CartService.clearCart)",
+      "note": "Domain edge that currently extracts correctly (OrderService \u2192 CartService.clearCart)",
       "direct_callees": [
-        { "name": "clearCart", "class": "CartService", "severity": "required" }
+        {
+          "name": "clearCart",
+          "class": "CartService",
+          "severity": "required"
+        }
       ]
     },
     "cartServiceClearCart": {
-      "match": { "name": "clearCart", "class": "CartService" },
+      "match": {
+        "name": "clearCart",
+        "class": "CartService"
+      },
       "severity": "required",
       "blast": {
-        "exact_direct_callers": ["checkout"],
+        "exact_direct_callers": [
+          "checkout"
+        ],
         "min_score": 0.1
       }
     },
     "correctnessShared": {
-      "match": { "name": "correctnessShared", "class": "CorrectnessHarness" },
+      "match": {
+        "name": "correctnessShared",
+        "class": "CorrectnessHarness"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -165,9 +267,15 @@
         "language": "java"
       },
       "exact_callees": [],
-      "exact_callers": ["correctnessLeft", "correctnessRight"],
+      "exact_callers": [
+        "correctnessLeft",
+        "correctnessRight"
+      ],
       "blast": {
-        "exact_direct_callers": ["correctnessLeft", "correctnessRight"],
+        "exact_direct_callers": [
+          "correctnessLeft",
+          "correctnessRight"
+        ],
         "exact_impact_zone": [
           "correctnessLeft",
           "correctnessRight",
@@ -177,7 +285,10 @@
       }
     },
     "correctnessDiamond": {
-      "match": { "name": "correctnessDiamond", "class": "CorrectnessHarness" },
+      "match": {
+        "name": "correctnessDiamond",
+        "class": "CorrectnessHarness"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -187,11 +298,99 @@
         "file_suffix": "CorrectnessHarness.java",
         "language": "java"
       },
-      "exact_callees": ["correctnessLeft", "correctnessRight"],
+      "exact_callees": [
+        "correctnessLeft",
+        "correctnessRight"
+      ],
       "exact_callers": [],
       "blast": {
         "exact_direct_callers": [],
         "exact_impact_zone": []
+      }
+    },
+    "cfgShortCircuit": {
+      "match": {
+        "name": "cfgShortCircuit",
+        "class": "CfgFeatures"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfgShortCircuit",
+        "file_suffix": "CfgFeatures.java",
+        "language": "java",
+        "class_context": "CfgFeatures",
+        "canonical_fqn": "CfgFeatures::cfgShortCircuit"
+      },
+      "cfg": {
+        "min_blocks": 6,
+        "statements_contain": [
+          "a",
+          "b"
+        ]
+      }
+    },
+    "cfgEnhancedFor": {
+      "match": {
+        "name": "cfgEnhancedFor",
+        "class": "CfgFeatures"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfgEnhancedFor",
+        "file_suffix": "CfgFeatures.java",
+        "language": "java",
+        "class_context": "CfgFeatures",
+        "canonical_fqn": "CfgFeatures::cfgEnhancedFor"
+      },
+      "cfg": {
+        "min_blocks": 4,
+        "statements_contain": [
+          "for-each"
+        ]
+      }
+    },
+    "cfgSwitchArrow": {
+      "match": {
+        "name": "cfgSwitchArrow",
+        "class": "CfgFeatures"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfgSwitchArrow",
+        "file_suffix": "CfgFeatures.java",
+        "language": "java",
+        "class_context": "CfgFeatures",
+        "canonical_fqn": "CfgFeatures::cfgSwitchArrow"
+      },
+      "cfg": {
+        "min_blocks": 5,
+        "statements_contain": [
+          "1"
+        ]
+      }
+    },
+    "cfgTryWithResources": {
+      "match": {
+        "name": "cfgTryWithResources",
+        "class": "CfgFeatures"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfgTryWithResources",
+        "file_suffix": "CfgFeatures.java",
+        "language": "java",
+        "class_context": "CfgFeatures",
+        "canonical_fqn": "CfgFeatures::cfgTryWithResources"
+      },
+      "cfg": {
+        "min_blocks": 3,
+        "statements_contain": [
+          "close()"
+        ]
       }
     }
   },
@@ -213,27 +412,46 @@
     "B5_inspect_cfg_present": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B6_cfg_calls_subset_of_calls_edges": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid"
+      ]
     },
     "B7_pdg_lines_subset_cfg": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B8_dom_blocks_match_cfg": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B9_blast_target_name": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     }
   }
 }

--- a/rbuilder-tests/ecommerce-java/src/main/java/com/example/ecommerce/correctness/CfgFeatures.java
+++ b/rbuilder-tests/ecommerce-java/src/main/java/com/example/ecommerce/correctness/CfgFeatures.java
@@ -1,0 +1,49 @@
+package com.example.ecommerce.correctness;
+
+/**
+ * CFG feature probes for rBuilder expected-facts (Java lowering coverage).
+ */
+public final class CfgFeatures {
+
+    private CfgFeatures() {}
+
+    public static int cfgShortCircuit(boolean a, boolean b) {
+        if (a && b) {
+            return 1;
+        }
+        return 0;
+    }
+
+    public static int cfgEnhancedFor(int[] xs) {
+        int total = 0;
+        for (int v : xs) {
+            total += v;
+        }
+        return total;
+    }
+
+    public static int cfgSwitchArrow(int x) {
+        return switch (x) {
+            case 1 -> 10;
+            case 2 -> 20;
+            default -> 0;
+        };
+    }
+
+    public static int cfgTryWithResources() {
+        try (Res r = new Res()) {
+            return r.value();
+        }
+    }
+
+    static final class Res implements AutoCloseable {
+        int value() {
+            return 1;
+        }
+
+        @Override
+        public void close() {
+            // synthetic close() for CFG
+        }
+    }
+}

--- a/rbuilder-tests/ecommerce-javascript/correctness/expected-facts.json
+++ b/rbuilder-tests/ecommerce-javascript/correctness/expected-facts.json
@@ -9,7 +9,9 @@
   },
   "symbols": {
     "correctnessRoot": {
-      "match": { "name": "correctnessRoot" },
+      "match": {
+        "name": "correctnessRoot"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -17,41 +19,81 @@
         "canonical_fqn": "correctnessRoot",
         "file_suffix": "correctness.js"
       },
-      "exact_callees": ["correctnessMid"],
+      "exact_callees": [
+        "correctnessMid"
+      ],
       "exact_callers": [],
       "blast": {
         "exact_direct_callers": [],
         "exact_impact_zone": []
       },
       "ast": {
-        "must_call": ["correctnessMid"],
-        "statements_contain": ["const value = correctnessMid();", "flag"],
-        "statement_kinds_any": ["Expression", "Branch", "Return"]
+        "must_call": [
+          "correctnessMid"
+        ],
+        "statements_contain": [
+          "const value = correctnessMid();",
+          "flag"
+        ],
+        "statement_kinds_any": [
+          "Expression",
+          "Branch",
+          "Return"
+        ]
       },
       "cfg": {
         "exact_block_count": 7,
         "exact_edge_count": 6,
-        "exact_edge_kinds": ["iffalse", "iftrue", "next", "next", "return", "return"],
-        "statements_contain": ["correctnessMid()"]
+        "exact_edge_kinds": [
+          "iffalse",
+          "iftrue",
+          "next",
+          "next",
+          "return",
+          "return"
+        ],
+        "statements_contain": [
+          "correctnessMid()"
+        ]
       },
       "pdg": {
         "exact_data_deps": 2,
         "exact_control_deps": 1,
         "exact_node_count": 4,
-        "exact_node_kinds": ["Branch", "Expression", "Return", "Return"],
-        "data_edges": [{ "variable": "value" }],
-        "node_labels_contain": ["correctnessMid()", "value * 2"]
+        "exact_node_kinds": [
+          "Branch",
+          "Expression",
+          "Return",
+          "Return"
+        ],
+        "data_edges": [
+          {
+            "variable": "value"
+          }
+        ],
+        "node_labels_contain": [
+          "correctnessMid()",
+          "value * 2"
+        ]
       },
       "dom": {
         "exact_block_count": 7,
         "idom_contains": [
-          { "block": 3, "immediate_dominator": 3 },
-          { "block": 4, "immediate_dominator": 3 }
+          {
+            "block": 3,
+            "immediate_dominator": 3
+          },
+          {
+            "block": 4,
+            "immediate_dominator": 3
+          }
         ]
       }
     },
     "correctnessMid": {
-      "match": { "name": "correctnessMid" },
+      "match": {
+        "name": "correctnessMid"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -59,39 +101,65 @@
         "canonical_fqn": "correctnessMid",
         "file_suffix": "correctness.js"
       },
-      "exact_callees": ["correctnessLeaf"],
-      "exact_callers": ["correctnessRoot"],
+      "exact_callees": [
+        "correctnessLeaf"
+      ],
+      "exact_callers": [
+        "correctnessRoot"
+      ],
       "blast": {
-        "exact_direct_callers": ["correctnessRoot"],
-        "exact_impact_zone": ["correctnessRoot"],
+        "exact_direct_callers": [
+          "correctnessRoot"
+        ],
+        "exact_impact_zone": [
+          "correctnessRoot"
+        ],
         "min_score": 0.1
       },
       "ast": {
-        "must_call": ["correctnessLeaf"],
-        "statements_contain": ["return correctnessLeaf() + 1;"],
-        "exact_statement_kinds": ["Return"]
+        "must_call": [
+          "correctnessLeaf"
+        ],
+        "statements_contain": [
+          "return correctnessLeaf() + 1;"
+        ],
+        "exact_statement_kinds": [
+          "Return"
+        ]
       },
       "cfg": {
         "exact_block_count": 2,
         "exact_edge_count": 1,
-        "exact_edge_kinds": ["return"]
+        "exact_edge_kinds": [
+          "return"
+        ]
       },
       "pdg": {
         "exact_data_deps": 0,
         "exact_control_deps": 0,
         "exact_node_count": 1,
-        "exact_node_kinds": ["Return"]
+        "exact_node_kinds": [
+          "Return"
+        ]
       },
       "dom": {
         "exact_block_count": 2,
         "exact_idom": [
-          { "block": 0, "immediate_dominator": 1 },
-          { "block": 1, "immediate_dominator": 1 }
+          {
+            "block": 0,
+            "immediate_dominator": 1
+          },
+          {
+            "block": 1,
+            "immediate_dominator": 1
+          }
         ]
       }
     },
     "correctnessLeaf": {
-      "match": { "name": "correctnessLeaf" },
+      "match": {
+        "name": "correctnessLeaf"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -100,68 +168,178 @@
         "file_suffix": "correctness.js"
       },
       "exact_callees": [],
-      "exact_callers": ["correctnessMid"],
+      "exact_callers": [
+        "correctnessMid"
+      ],
       "blast": {
-        "exact_direct_callers": ["correctnessMid"],
-        "exact_impact_zone": ["correctnessMid", "correctnessRoot"],
+        "exact_direct_callers": [
+          "correctnessMid"
+        ],
+        "exact_impact_zone": [
+          "correctnessMid",
+          "correctnessRoot"
+        ],
         "min_score": 0.1
       },
       "ast": {
-        "statements_contain": ["return 42;"],
-        "exact_statement_kinds": ["Return"]
+        "statements_contain": [
+          "return 42;"
+        ],
+        "exact_statement_kinds": [
+          "Return"
+        ]
       },
       "cfg": {
         "exact_block_count": 2,
         "exact_edge_count": 1,
-        "exact_edge_kinds": ["return"]
+        "exact_edge_kinds": [
+          "return"
+        ]
       },
       "pdg": {
         "exact_data_deps": 0,
         "exact_control_deps": 0,
         "exact_node_count": 1,
-        "exact_node_kinds": ["Return"]
+        "exact_node_kinds": [
+          "Return"
+        ]
       },
-      "dom": { "exact_block_count": 2 }
+      "dom": {
+        "exact_block_count": 2
+      }
     },
     "orderServiceCheckout": {
-      "match": { "name": "checkout" },
+      "match": {
+        "name": "checkout"
+      },
       "severity": "best_effort",
       "direct_callees": [
-        { "name": "clearCart", "severity": "best_effort" }
+        {
+          "name": "clearCart",
+          "severity": "best_effort"
+        }
       ]
+    },
+    "cfgShortCircuit": {
+      "match": {
+        "name": "cfgShortCircuit"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfgShortCircuit",
+        "file_suffix": "cfg_features.js"
+      },
+      "cfg": {
+        "min_blocks": 6,
+        "statements_contain": [
+          "a",
+          "b"
+        ]
+      }
+    },
+    "cfgForLoop": {
+      "match": {
+        "name": "cfgForLoop"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfgForLoop",
+        "file_suffix": "cfg_features.js"
+      },
+      "cfg": {
+        "min_blocks": 4,
+        "statements_contain": []
+      }
+    },
+    "cfgTryCatch": {
+      "match": {
+        "name": "cfgTryCatch"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfgTryCatch",
+        "file_suffix": "cfg_features.js"
+      },
+      "cfg": {
+        "min_blocks": 3,
+        "statements_contain": []
+      }
+    },
+    "cfgSwitch": {
+      "match": {
+        "name": "cfgSwitch"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfgSwitch",
+        "file_suffix": "cfg_features.js"
+      },
+      "cfg": {
+        "min_blocks": 6,
+        "statements_contain": []
+      }
     }
   },
   "invariants": {
     "B1_blast_vs_calls": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessLeaf", "correctnessMid"]
+      "symbols": [
+        "correctnessLeaf",
+        "correctnessMid"
+      ]
     },
-    "B2_gql_calls_nonzero": { "enabled": true, "severity": "required" },
+    "B2_gql_calls_nonzero": {
+      "enabled": true,
+      "severity": "required"
+    },
     "B5_inspect_cfg_present": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B6_cfg_calls_subset_of_calls_edges": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid"
+      ]
     },
     "B7_pdg_lines_subset_cfg": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B8_dom_blocks_match_cfg": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B9_blast_target_name": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     }
   }
 }

--- a/rbuilder-tests/ecommerce-javascript/correctness/expected-facts.json
+++ b/rbuilder-tests/ecommerce-javascript/correctness/expected-facts.json
@@ -25,25 +25,25 @@
       },
       "ast": {
         "must_call": ["correctnessMid"],
-        "statements_contain": ["const value = correctnessMid();", "if (flag)"],
+        "statements_contain": ["const value = correctnessMid();", "flag"],
         "statement_kinds_any": ["Expression", "Branch", "Return"]
       },
       "cfg": {
-        "exact_block_count": 5,
-        "exact_edge_count": 5,
-        "exact_edge_kinds": ["iffalse", "iftrue", "next", "next", "return"],
+        "exact_block_count": 7,
+        "exact_edge_count": 6,
+        "exact_edge_kinds": ["iffalse", "iftrue", "next", "next", "return", "return"],
         "statements_contain": ["correctnessMid()"]
       },
       "pdg": {
-        "exact_data_deps": 1,
-        "exact_control_deps": 0,
-        "exact_node_count": 3,
-        "exact_node_kinds": ["Branch", "Expression", "Return"],
+        "exact_data_deps": 2,
+        "exact_control_deps": 1,
+        "exact_node_count": 4,
+        "exact_node_kinds": ["Branch", "Expression", "Return", "Return"],
         "data_edges": [{ "variable": "value" }],
         "node_labels_contain": ["correctnessMid()", "value * 2"]
       },
       "dom": {
-        "exact_block_count": 5,
+        "exact_block_count": 7,
         "idom_contains": [
           { "block": 3, "immediate_dominator": 3 },
           { "block": 4, "immediate_dominator": 3 }

--- a/rbuilder-tests/ecommerce-javascript/src/cfg_features.js
+++ b/rbuilder-tests/ecommerce-javascript/src/cfg_features.js
@@ -1,0 +1,39 @@
+/**
+ * CFG feature probes for rBuilder expected-facts (JavaScript lowering coverage).
+ */
+
+function cfgShortCircuit(a, b) {
+  if (a && b) {
+    return 1;
+  }
+  return 0;
+}
+
+function cfgForLoop(xs) {
+  let total = 0;
+  for (let i = 0; i < xs.length; i++) {
+    total += xs[i];
+  }
+  return total;
+}
+
+function cfgTryCatch() {
+  try {
+    throw new Error("boom");
+  } catch (e) {
+    return 1;
+  }
+}
+
+function cfgSwitch(x) {
+  switch (x) {
+    case 1:
+      return 10;
+    case 2:
+      return 20;
+    default:
+      return 0;
+  }
+}
+
+module.exports = { cfgShortCircuit, cfgForLoop, cfgTryCatch, cfgSwitch };

--- a/rbuilder-tests/ecommerce-python/app/cfg_features.py
+++ b/rbuilder-tests/ecommerce-python/app/cfg_features.py
@@ -1,0 +1,21 @@
+"""CFG feature probes for rBuilder expected-facts (Python lowering coverage)."""
+
+
+def cfg_short_circuit(a: bool, b: bool) -> int:
+    if a and b:
+        return 1
+    return 0
+
+
+def cfg_for_loop(xs: list[int]) -> int:
+    total = 0
+    for v in xs:
+        total += v
+    return total
+
+
+def cfg_try_except() -> int:
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        return 1

--- a/rbuilder-tests/ecommerce-python/correctness/expected-facts.json
+++ b/rbuilder-tests/ecommerce-python/correctness/expected-facts.json
@@ -9,7 +9,9 @@
   },
   "symbols": {
     "correctnessRoot": {
-      "match": { "name": "correctness_root" },
+      "match": {
+        "name": "correctness_root"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -18,40 +20,75 @@
         "file_suffix": "correctness.py",
         "language": "python"
       },
-      "exact_callees": ["correctness_mid"],
+      "exact_callees": [
+        "correctness_mid"
+      ],
       "exact_callers": [],
       "blast": {
         "exact_direct_callers": [],
         "exact_impact_zone": []
       },
       "ast": {
-        "must_call": ["correctness_mid"],
-        "statements_contain": ["value = correctness_mid()", "if flag"],
-        "statement_kinds_any": ["Assignment", "Branch", "Return"]
+        "must_call": [
+          "correctness_mid"
+        ],
+        "statements_contain": [
+          "value = correctness_mid()",
+          "flag"
+        ],
+        "statement_kinds_any": [
+          "Assignment",
+          "Branch",
+          "Return"
+        ]
       },
       "cfg": {
-        "exact_block_count": 5,
-        "exact_edge_count": 5,
-        "exact_edge_kinds": ["iffalse", "iftrue", "next", "next", "return"],
-        "statements_contain": ["correctness_mid()"]
+        "exact_block_count": 7,
+        "exact_edge_count": 6,
+        "exact_edge_kinds": [
+          "iffalse",
+          "iftrue",
+          "next",
+          "next",
+          "return",
+          "return"
+        ],
+        "statements_contain": [
+          "correctness_mid()"
+        ]
       },
       "pdg": {
         "exact_data_deps": 2,
-        "exact_control_deps": 0,
-        "exact_node_count": 4,
-        "data_edges": [{ "variable": "value" }],
-        "node_labels_contain": ["correctness_mid()", "value * 2"]
+        "exact_control_deps": 1,
+        "exact_node_count": 5,
+        "data_edges": [
+          {
+            "variable": "value"
+          }
+        ],
+        "node_labels_contain": [
+          "correctness_mid()",
+          "value * 2"
+        ]
       },
       "dom": {
-        "exact_block_count": 5,
+        "exact_block_count": 7,
         "idom_contains": [
-          { "block": 3, "immediate_dominator": 3 },
-          { "block": 4, "immediate_dominator": 3 }
+          {
+            "block": 3,
+            "immediate_dominator": 3
+          },
+          {
+            "block": 4,
+            "immediate_dominator": 3
+          }
         ]
       }
     },
     "correctnessMid": {
-      "match": { "name": "correctness_mid" },
+      "match": {
+        "name": "correctness_mid"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -60,32 +97,52 @@
         "file_suffix": "correctness.py",
         "language": "python"
       },
-      "exact_callees": ["correctness_leaf"],
-      "exact_callers": ["correctness_root"],
+      "exact_callees": [
+        "correctness_leaf"
+      ],
+      "exact_callers": [
+        "correctness_root"
+      ],
       "blast": {
-        "exact_direct_callers": ["correctness_root"],
-        "exact_impact_zone": ["correctness_root"],
+        "exact_direct_callers": [
+          "correctness_root"
+        ],
+        "exact_impact_zone": [
+          "correctness_root"
+        ],
         "min_score": 0.1
       },
       "ast": {
-        "must_call": ["correctness_leaf"],
-        "statements_contain": ["return correctness_leaf() + 1"]
+        "must_call": [
+          "correctness_leaf"
+        ],
+        "statements_contain": [
+          "return correctness_leaf() + 1"
+        ]
       },
       "cfg": {
         "exact_block_count": 2,
         "exact_edge_count": 1,
-        "exact_edge_kinds": ["return"]
+        "exact_edge_kinds": [
+          "return"
+        ]
       },
       "pdg": {
         "exact_data_deps": 0,
         "exact_control_deps": 0,
         "exact_node_count": 2,
-        "node_labels_contain": ["correctness_leaf()"]
+        "node_labels_contain": [
+          "correctness_leaf()"
+        ]
       },
-      "dom": { "exact_block_count": 2 }
+      "dom": {
+        "exact_block_count": 2
+      }
     },
     "correctnessLeaf": {
-      "match": { "name": "correctness_leaf" },
+      "match": {
+        "name": "correctness_leaf"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -95,29 +152,44 @@
         "language": "python"
       },
       "exact_callees": [],
-      "exact_callers": ["correctness_mid"],
+      "exact_callers": [
+        "correctness_mid"
+      ],
       "blast": {
-        "exact_direct_callers": ["correctness_mid"],
-        "exact_impact_zone": ["correctness_mid", "correctness_root"],
+        "exact_direct_callers": [
+          "correctness_mid"
+        ],
+        "exact_impact_zone": [
+          "correctness_mid",
+          "correctness_root"
+        ],
         "min_score": 0.1
       },
       "ast": {
-        "statements_contain": ["return 42"]
+        "statements_contain": [
+          "return 42"
+        ]
       },
       "cfg": {
         "exact_block_count": 2,
         "exact_edge_count": 1,
-        "exact_edge_kinds": ["return"]
+        "exact_edge_kinds": [
+          "return"
+        ]
       },
       "pdg": {
         "exact_data_deps": 0,
         "exact_control_deps": 0,
         "exact_node_count": 2
       },
-      "dom": { "exact_block_count": 2 }
+      "dom": {
+        "exact_block_count": 2
+      }
     },
     "correctnessShared": {
-      "match": { "name": "correctness_shared" },
+      "match": {
+        "name": "correctness_shared"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -127,9 +199,15 @@
         "language": "python"
       },
       "exact_callees": [],
-      "exact_callers": ["correctness_left", "correctness_right"],
+      "exact_callers": [
+        "correctness_left",
+        "correctness_right"
+      ],
       "blast": {
-        "exact_direct_callers": ["correctness_left", "correctness_right"],
+        "exact_direct_callers": [
+          "correctness_left",
+          "correctness_right"
+        ],
         "exact_impact_zone": [
           "correctness_left",
           "correctness_right",
@@ -139,7 +217,9 @@
       }
     },
     "correctnessDiamond": {
-      "match": { "name": "correctness_diamond" },
+      "match": {
+        "name": "correctness_diamond"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -148,11 +228,64 @@
         "file_suffix": "correctness.py",
         "language": "python"
       },
-      "exact_callees": ["correctness_left", "correctness_right"],
+      "exact_callees": [
+        "correctness_left",
+        "correctness_right"
+      ],
       "exact_callers": [],
       "blast": {
         "exact_direct_callers": [],
         "exact_impact_zone": []
+      }
+    },
+    "cfg_short_circuit": {
+      "match": {
+        "name": "cfg_short_circuit"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfg_short_circuit",
+        "file_suffix": "cfg_features.py",
+        "language": "python"
+      },
+      "cfg": {
+        "min_blocks": 5,
+        "statements_contain": [
+          "a and b"
+        ]
+      }
+    },
+    "cfg_for_loop": {
+      "match": {
+        "name": "cfg_for_loop"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfg_for_loop",
+        "file_suffix": "cfg_features.py",
+        "language": "python"
+      },
+      "cfg": {
+        "min_blocks": 4,
+        "statements_contain": []
+      }
+    },
+    "cfg_try_except": {
+      "match": {
+        "name": "cfg_try_except"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfg_try_except",
+        "file_suffix": "cfg_features.py",
+        "language": "python"
+      },
+      "cfg": {
+        "min_blocks": 4,
+        "statements_contain": []
       }
     }
   },
@@ -160,33 +293,60 @@
     "B1_blast_vs_calls": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessLeaf", "correctnessMid", "correctnessShared"]
+      "symbols": [
+        "correctnessLeaf",
+        "correctnessMid",
+        "correctnessShared"
+      ]
     },
-    "B2_gql_calls_nonzero": { "enabled": true, "severity": "required" },
+    "B2_gql_calls_nonzero": {
+      "enabled": true,
+      "severity": "required"
+    },
     "B5_inspect_cfg_present": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B6_cfg_calls_subset_of_calls_edges": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid"
+      ]
     },
     "B7_pdg_lines_subset_cfg": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B8_dom_blocks_match_cfg": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B9_blast_target_name": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf", "correctnessShared"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf",
+        "correctnessShared"
+      ]
     }
   }
 }

--- a/rbuilder-tests/ecommerce-rust/correctness/expected-facts.json
+++ b/rbuilder-tests/ecommerce-rust/correctness/expected-facts.json
@@ -9,7 +9,9 @@
   },
   "symbols": {
     "correctnessRoot": {
-      "match": { "name": "correctness_root" },
+      "match": {
+        "name": "correctness_root"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -18,39 +20,69 @@
         "file_suffix": "correctness.rs",
         "language": "rust"
       },
-      "exact_callees": ["correctness_mid"],
+      "exact_callees": [
+        "correctness_mid"
+      ],
       "exact_callers": [],
       "blast": {
         "exact_direct_callers": [],
         "exact_impact_zone": []
       },
       "ast": {
-        "must_call": ["correctness_mid"],
-        "statements_contain": ["let value = correctness_mid();", "flag"]
+        "must_call": [
+          "correctness_mid"
+        ],
+        "statements_contain": [
+          "let value = correctness_mid();",
+          "flag"
+        ]
       },
       "cfg": {
         "exact_block_count": 6,
         "exact_edge_count": 6,
-        "exact_edge_kinds": ["iffalse", "iftrue", "next", "next", "next", "next"],
-        "statements_contain": ["correctness_mid()"]
+        "exact_edge_kinds": [
+          "iffalse",
+          "iftrue",
+          "next",
+          "next",
+          "next",
+          "next"
+        ],
+        "statements_contain": [
+          "correctness_mid()"
+        ]
       },
       "pdg": {
         "exact_data_deps": 2,
         "exact_control_deps": 2,
         "exact_node_count": 4,
-        "data_edges": [{ "variable": "value" }],
-        "node_labels_contain": ["correctness_mid()"]
+        "data_edges": [
+          {
+            "variable": "value"
+          }
+        ],
+        "node_labels_contain": [
+          "correctness_mid()"
+        ]
       },
       "dom": {
         "exact_block_count": 6,
         "idom_contains": [
-          { "block": 2, "immediate_dominator": 2 },
-          { "block": 3, "immediate_dominator": 2 }
+          {
+            "block": 2,
+            "immediate_dominator": 2
+          },
+          {
+            "block": 3,
+            "immediate_dominator": 2
+          }
         ]
       }
     },
     "correctnessMid": {
-      "match": { "name": "correctness_mid" },
+      "match": {
+        "name": "correctness_mid"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -59,38 +91,62 @@
         "file_suffix": "correctness.rs",
         "language": "rust"
       },
-      "exact_callees": ["correctness_leaf"],
-      "exact_callers": ["correctness_root"],
+      "exact_callees": [
+        "correctness_leaf"
+      ],
+      "exact_callers": [
+        "correctness_root"
+      ],
       "blast": {
-        "exact_direct_callers": ["correctness_root"],
-        "exact_impact_zone": ["correctness_root"],
+        "exact_direct_callers": [
+          "correctness_root"
+        ],
+        "exact_impact_zone": [
+          "correctness_root"
+        ],
         "min_score": 0.1
       },
       "ast": {
-        "must_call": ["correctness_leaf"],
-        "statements_contain": ["correctness_leaf() + 1"]
+        "must_call": [
+          "correctness_leaf"
+        ],
+        "statements_contain": [
+          "correctness_leaf() + 1"
+        ]
       },
       "cfg": {
         "exact_block_count": 2,
         "exact_edge_count": 1,
-        "exact_edge_kinds": ["next"]
+        "exact_edge_kinds": [
+          "next"
+        ]
       },
       "pdg": {
         "exact_data_deps": 0,
         "exact_control_deps": 0,
         "exact_node_count": 1,
-        "node_labels_contain": ["correctness_leaf()"]
+        "node_labels_contain": [
+          "correctness_leaf()"
+        ]
       },
       "dom": {
         "exact_block_count": 2,
         "exact_idom": [
-          { "block": 0, "immediate_dominator": 1 },
-          { "block": 1, "immediate_dominator": 1 }
+          {
+            "block": 0,
+            "immediate_dominator": 1
+          },
+          {
+            "block": 1,
+            "immediate_dominator": 1
+          }
         ]
       }
     },
     "correctnessLeaf": {
-      "match": { "name": "correctness_leaf" },
+      "match": {
+        "name": "correctness_leaf"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -100,37 +156,60 @@
         "language": "rust"
       },
       "exact_callees": [],
-      "exact_callers": ["correctness_mid"],
+      "exact_callers": [
+        "correctness_mid"
+      ],
       "blast": {
-        "exact_direct_callers": ["correctness_mid"],
-        "exact_impact_zone": ["correctness_mid", "correctness_root"],
+        "exact_direct_callers": [
+          "correctness_mid"
+        ],
+        "exact_impact_zone": [
+          "correctness_mid",
+          "correctness_root"
+        ],
         "min_score": 0.1
       },
       "ast": {
-        "statements_contain": ["42"],
-        "exact_statement_kinds": ["Expression"]
+        "statements_contain": [
+          "42"
+        ],
+        "exact_statement_kinds": [
+          "Expression"
+        ]
       },
       "cfg": {
         "exact_block_count": 2,
         "exact_edge_count": 1,
-        "exact_edge_kinds": ["next"]
+        "exact_edge_kinds": [
+          "next"
+        ]
       },
       "pdg": {
         "exact_data_deps": 0,
         "exact_control_deps": 0,
         "exact_node_count": 1,
-        "exact_node_kinds": ["Expression"]
+        "exact_node_kinds": [
+          "Expression"
+        ]
       },
       "dom": {
         "exact_block_count": 2,
         "exact_idom": [
-          { "block": 0, "immediate_dominator": 1 },
-          { "block": 1, "immediate_dominator": 1 }
+          {
+            "block": 0,
+            "immediate_dominator": 1
+          },
+          {
+            "block": 1,
+            "immediate_dominator": 1
+          }
         ]
       }
     },
     "correctnessShared": {
-      "match": { "name": "correctness_shared" },
+      "match": {
+        "name": "correctness_shared"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -140,9 +219,15 @@
         "language": "rust"
       },
       "exact_callees": [],
-      "exact_callers": ["correctness_left", "correctness_right"],
+      "exact_callers": [
+        "correctness_left",
+        "correctness_right"
+      ],
       "blast": {
-        "exact_direct_callers": ["correctness_left", "correctness_right"],
+        "exact_direct_callers": [
+          "correctness_left",
+          "correctness_right"
+        ],
         "exact_impact_zone": [
           "correctness_left",
           "correctness_right",
@@ -152,7 +237,9 @@
       }
     },
     "correctnessDiamond": {
-      "match": { "name": "correctness_diamond" },
+      "match": {
+        "name": "correctness_diamond"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -161,11 +248,103 @@
         "file_suffix": "correctness.rs",
         "language": "rust"
       },
-      "exact_callees": ["correctness_left", "correctness_right"],
+      "exact_callees": [
+        "correctness_left",
+        "correctness_right"
+      ],
       "exact_callers": [],
       "blast": {
         "exact_direct_callers": [],
         "exact_impact_zone": []
+      }
+    },
+    "cfg_short_circuit": {
+      "match": {
+        "name": "cfg_short_circuit"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfg_short_circuit",
+        "file_suffix": "cfg_features.rs",
+        "language": "rust"
+      },
+      "cfg": {
+        "min_blocks": 5,
+        "statements_contain": [
+          "a",
+          "b"
+        ]
+      }
+    },
+    "cfg_match_guard": {
+      "match": {
+        "name": "cfg_match_guard"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfg_match_guard",
+        "file_suffix": "cfg_features.rs",
+        "language": "rust"
+      },
+      "cfg": {
+        "min_blocks": 6,
+        "statements_contain": [
+          "n > 0"
+        ]
+      }
+    },
+    "cfg_try_op": {
+      "match": {
+        "name": "cfg_try_op"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfg_try_op",
+        "file_suffix": "cfg_features.rs",
+        "language": "rust"
+      },
+      "cfg": {
+        "min_blocks": 3,
+        "statements_contain": [
+          "?"
+        ]
+      }
+    },
+    "cfg_for_in": {
+      "match": {
+        "name": "cfg_for_in"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfg_for_in",
+        "file_suffix": "cfg_features.rs",
+        "language": "rust"
+      },
+      "cfg": {
+        "min_blocks": 4,
+        "statements_contain": []
+      }
+    },
+    "cfg_await": {
+      "match": {
+        "name": "cfg_await"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfg_await",
+        "file_suffix": "cfg_features.rs",
+        "language": "rust"
+      },
+      "cfg": {
+        "min_blocks": 2,
+        "statements_contain": [
+          "await"
+        ]
       }
     }
   },
@@ -173,33 +352,60 @@
     "B1_blast_vs_calls": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessLeaf", "correctnessMid", "correctnessShared"]
+      "symbols": [
+        "correctnessLeaf",
+        "correctnessMid",
+        "correctnessShared"
+      ]
     },
-    "B2_gql_calls_nonzero": { "enabled": true, "severity": "required" },
+    "B2_gql_calls_nonzero": {
+      "enabled": true,
+      "severity": "required"
+    },
     "B5_inspect_cfg_present": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B6_cfg_calls_subset_of_calls_edges": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid"
+      ]
     },
     "B7_pdg_lines_subset_cfg": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B8_dom_blocks_match_cfg": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B9_blast_target_name": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf", "correctnessShared"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf",
+        "correctnessShared"
+      ]
     }
   }
 }

--- a/rbuilder-tests/ecommerce-rust/correctness/expected-facts.json
+++ b/rbuilder-tests/ecommerce-rust/correctness/expected-facts.json
@@ -26,23 +26,23 @@
       },
       "ast": {
         "must_call": ["correctness_mid"],
-        "statements_contain": ["let value = correctness_mid();", "if flag"]
+        "statements_contain": ["let value = correctness_mid();", "flag"]
       },
       "cfg": {
-        "exact_block_count": 5,
-        "exact_edge_count": 5,
-        "exact_edge_kinds": ["iffalse", "iftrue", "next", "next", "next"],
+        "exact_block_count": 6,
+        "exact_edge_count": 6,
+        "exact_edge_kinds": ["iffalse", "iftrue", "next", "next", "next", "next"],
         "statements_contain": ["correctness_mid()"]
       },
       "pdg": {
-        "exact_data_deps": 3,
+        "exact_data_deps": 2,
         "exact_control_deps": 2,
         "exact_node_count": 4,
         "data_edges": [{ "variable": "value" }],
         "node_labels_contain": ["correctness_mid()"]
       },
       "dom": {
-        "exact_block_count": 5,
+        "exact_block_count": 6,
         "idom_contains": [
           { "block": 2, "immediate_dominator": 2 },
           { "block": 3, "immediate_dominator": 2 }

--- a/rbuilder-tests/ecommerce-rust/src/cfg_features.rs
+++ b/rbuilder-tests/ecommerce-rust/src/cfg_features.rs
@@ -1,0 +1,36 @@
+//! CFG feature probes for rBuilder expected-facts (Rust lowering coverage).
+
+#![allow(dead_code)]
+
+pub fn cfg_short_circuit(a: bool, b: bool) -> i32 {
+    if a && b {
+        1
+    } else {
+        0
+    }
+}
+
+pub fn cfg_match_guard(x: i32) -> i32 {
+    match x {
+        n if n > 0 => n,
+        _ => 0,
+    }
+}
+
+pub fn cfg_try_op(x: Result<i32, ()>) -> Result<i32, ()> {
+    let v = x?;
+    Ok(v + 1)
+}
+
+pub fn cfg_for_in(xs: &[i32]) -> i32 {
+    let mut total = 0;
+    for v in xs {
+        total += *v;
+    }
+    total
+}
+
+pub async fn cfg_await() -> i32 {
+    let x = async { 1 }.await;
+    x
+}

--- a/rbuilder-tests/ecommerce-rust/src/main.rs
+++ b/rbuilder-tests/ecommerce-rust/src/main.rs
@@ -1,5 +1,6 @@
 mod config;
 mod coolstore;
+mod cfg_features;
 mod correctness;
 mod db;
 mod dto;

--- a/rbuilder-tests/ecommerce-typescript/correctness/expected-facts.json
+++ b/rbuilder-tests/ecommerce-typescript/correctness/expected-facts.json
@@ -9,7 +9,9 @@
   },
   "symbols": {
     "correctnessRoot": {
-      "match": { "name": "correctnessRoot" },
+      "match": {
+        "name": "correctnessRoot"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -17,41 +19,81 @@
         "canonical_fqn": "correctnessRoot",
         "file_suffix": "correctness.ts"
       },
-      "exact_callees": ["correctnessMid"],
+      "exact_callees": [
+        "correctnessMid"
+      ],
       "exact_callers": [],
       "blast": {
         "exact_direct_callers": [],
         "exact_impact_zone": []
       },
       "ast": {
-        "must_call": ["correctnessMid"],
-        "statements_contain": ["const value = correctnessMid();", "if (flag)"],
-        "statement_kinds_any": ["Expression", "Branch", "Return"]
+        "must_call": [
+          "correctnessMid"
+        ],
+        "statements_contain": [
+          "const value = correctnessMid();",
+          "flag"
+        ],
+        "statement_kinds_any": [
+          "Expression",
+          "Branch",
+          "Return"
+        ]
       },
       "cfg": {
-        "exact_block_count": 5,
-        "exact_edge_count": 5,
-        "exact_edge_kinds": ["iffalse", "iftrue", "next", "next", "return"],
-        "statements_contain": ["correctnessMid()"]
+        "exact_block_count": 7,
+        "exact_edge_count": 6,
+        "exact_edge_kinds": [
+          "iffalse",
+          "iftrue",
+          "next",
+          "next",
+          "return",
+          "return"
+        ],
+        "statements_contain": [
+          "correctnessMid()"
+        ]
       },
       "pdg": {
-        "exact_data_deps": 1,
-        "exact_control_deps": 0,
-        "exact_node_count": 3,
-        "exact_node_kinds": ["Branch", "Expression", "Return"],
-        "data_edges": [{ "variable": "value" }],
-        "node_labels_contain": ["correctnessMid()", "value * 2"]
+        "exact_data_deps": 2,
+        "exact_control_deps": 1,
+        "exact_node_count": 4,
+        "exact_node_kinds": [
+          "Branch",
+          "Expression",
+          "Return",
+          "Return"
+        ],
+        "data_edges": [
+          {
+            "variable": "value"
+          }
+        ],
+        "node_labels_contain": [
+          "correctnessMid()",
+          "value * 2"
+        ]
       },
       "dom": {
-        "exact_block_count": 5,
+        "exact_block_count": 7,
         "idom_contains": [
-          { "block": 3, "immediate_dominator": 3 },
-          { "block": 4, "immediate_dominator": 3 }
+          {
+            "block": 3,
+            "immediate_dominator": 3
+          },
+          {
+            "block": 4,
+            "immediate_dominator": 3
+          }
         ]
       }
     },
     "correctnessMid": {
-      "match": { "name": "correctnessMid" },
+      "match": {
+        "name": "correctnessMid"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -59,39 +101,65 @@
         "canonical_fqn": "correctnessMid",
         "file_suffix": "correctness.ts"
       },
-      "exact_callees": ["correctnessLeaf"],
-      "exact_callers": ["correctnessRoot"],
+      "exact_callees": [
+        "correctnessLeaf"
+      ],
+      "exact_callers": [
+        "correctnessRoot"
+      ],
       "blast": {
-        "exact_direct_callers": ["correctnessRoot"],
-        "exact_impact_zone": ["correctnessRoot"],
+        "exact_direct_callers": [
+          "correctnessRoot"
+        ],
+        "exact_impact_zone": [
+          "correctnessRoot"
+        ],
         "min_score": 0.1
       },
       "ast": {
-        "must_call": ["correctnessLeaf"],
-        "statements_contain": ["return correctnessLeaf() + 1;"],
-        "exact_statement_kinds": ["Return"]
+        "must_call": [
+          "correctnessLeaf"
+        ],
+        "statements_contain": [
+          "return correctnessLeaf() + 1;"
+        ],
+        "exact_statement_kinds": [
+          "Return"
+        ]
       },
       "cfg": {
         "exact_block_count": 2,
         "exact_edge_count": 1,
-        "exact_edge_kinds": ["return"]
+        "exact_edge_kinds": [
+          "return"
+        ]
       },
       "pdg": {
         "exact_data_deps": 0,
         "exact_control_deps": 0,
         "exact_node_count": 1,
-        "exact_node_kinds": ["Return"]
+        "exact_node_kinds": [
+          "Return"
+        ]
       },
       "dom": {
         "exact_block_count": 2,
         "exact_idom": [
-          { "block": 0, "immediate_dominator": 1 },
-          { "block": 1, "immediate_dominator": 1 }
+          {
+            "block": 0,
+            "immediate_dominator": 1
+          },
+          {
+            "block": 1,
+            "immediate_dominator": 1
+          }
         ]
       }
     },
     "correctnessLeaf": {
-      "match": { "name": "correctnessLeaf" },
+      "match": {
+        "name": "correctnessLeaf"
+      },
       "severity": "required",
       "unique": true,
       "identity": {
@@ -100,68 +168,178 @@
         "file_suffix": "correctness.ts"
       },
       "exact_callees": [],
-      "exact_callers": ["correctnessMid"],
+      "exact_callers": [
+        "correctnessMid"
+      ],
       "blast": {
-        "exact_direct_callers": ["correctnessMid"],
-        "exact_impact_zone": ["correctnessMid", "correctnessRoot"],
+        "exact_direct_callers": [
+          "correctnessMid"
+        ],
+        "exact_impact_zone": [
+          "correctnessMid",
+          "correctnessRoot"
+        ],
         "min_score": 0.1
       },
       "ast": {
-        "statements_contain": ["return 42;"],
-        "exact_statement_kinds": ["Return"]
+        "statements_contain": [
+          "return 42;"
+        ],
+        "exact_statement_kinds": [
+          "Return"
+        ]
       },
       "cfg": {
         "exact_block_count": 2,
         "exact_edge_count": 1,
-        "exact_edge_kinds": ["return"]
+        "exact_edge_kinds": [
+          "return"
+        ]
       },
       "pdg": {
         "exact_data_deps": 0,
         "exact_control_deps": 0,
         "exact_node_count": 1,
-        "exact_node_kinds": ["Return"]
+        "exact_node_kinds": [
+          "Return"
+        ]
       },
-      "dom": { "exact_block_count": 2 }
+      "dom": {
+        "exact_block_count": 2
+      }
     },
     "orderServiceCheckout": {
-      "match": { "name": "checkout" },
+      "match": {
+        "name": "checkout"
+      },
       "severity": "best_effort",
       "direct_callees": [
-        { "name": "clearCart", "severity": "best_effort" }
+        {
+          "name": "clearCart",
+          "severity": "best_effort"
+        }
       ]
+    },
+    "cfgShortCircuit": {
+      "match": {
+        "name": "cfgShortCircuit"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfgShortCircuit",
+        "file_suffix": "cfg_features.ts"
+      },
+      "cfg": {
+        "min_blocks": 6,
+        "statements_contain": [
+          "a",
+          "b"
+        ]
+      }
+    },
+    "cfgForLoop": {
+      "match": {
+        "name": "cfgForLoop"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfgForLoop",
+        "file_suffix": "cfg_features.ts"
+      },
+      "cfg": {
+        "min_blocks": 4,
+        "statements_contain": []
+      }
+    },
+    "cfgTryCatch": {
+      "match": {
+        "name": "cfgTryCatch"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfgTryCatch",
+        "file_suffix": "cfg_features.ts"
+      },
+      "cfg": {
+        "min_blocks": 3,
+        "statements_contain": []
+      }
+    },
+    "cfgSwitch": {
+      "match": {
+        "name": "cfgSwitch"
+      },
+      "severity": "required",
+      "unique": true,
+      "identity": {
+        "exact_name": "cfgSwitch",
+        "file_suffix": "cfg_features.ts"
+      },
+      "cfg": {
+        "min_blocks": 6,
+        "statements_contain": []
+      }
     }
   },
   "invariants": {
     "B1_blast_vs_calls": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessLeaf", "correctnessMid"]
+      "symbols": [
+        "correctnessLeaf",
+        "correctnessMid"
+      ]
     },
-    "B2_gql_calls_nonzero": { "enabled": true, "severity": "required" },
+    "B2_gql_calls_nonzero": {
+      "enabled": true,
+      "severity": "required"
+    },
     "B5_inspect_cfg_present": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B6_cfg_calls_subset_of_calls_edges": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid"
+      ]
     },
     "B7_pdg_lines_subset_cfg": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B8_dom_blocks_match_cfg": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     },
     "B9_blast_target_name": {
       "enabled": true,
       "severity": "required",
-      "symbols": ["correctnessRoot", "correctnessMid", "correctnessLeaf"]
+      "symbols": [
+        "correctnessRoot",
+        "correctnessMid",
+        "correctnessLeaf"
+      ]
     }
   }
 }

--- a/rbuilder-tests/ecommerce-typescript/src/cfg_features.ts
+++ b/rbuilder-tests/ecommerce-typescript/src/cfg_features.ts
@@ -1,0 +1,37 @@
+/**
+ * CFG feature probes for rBuilder expected-facts (TypeScript lowering coverage).
+ */
+
+export function cfgShortCircuit(a: boolean, b: boolean): number {
+  if (a && b) {
+    return 1;
+  }
+  return 0;
+}
+
+export function cfgForLoop(xs: number[]): number {
+  let total = 0;
+  for (let i = 0; i < xs.length; i++) {
+    total += xs[i];
+  }
+  return total;
+}
+
+export function cfgTryCatch(): number {
+  try {
+    throw new Error("boom");
+  } catch {
+    return 1;
+  }
+}
+
+export function cfgSwitch(x: number): number {
+  switch (x) {
+    case 1:
+      return 10;
+    case 2:
+      return 20;
+    default:
+      return 0;
+  }
+}

--- a/src/cli/discover_impl.rs
+++ b/src/cli/discover_impl.rs
@@ -541,7 +541,7 @@ pub(crate) fn run_full_analysis(
             Ok(None) => {}
             Err(err) => warn!(error = %err, "Failed to open CFG/PDG archive for field writes"),
         }
-        let _ = fw_start;
+        profile.field_write.secs = secs(fw_start.elapsed());
 
         if with_ast_skeleton {
             use crate::analysis::{

--- a/src/cli/stage_profile.rs
+++ b/src/cli/stage_profile.rs
@@ -27,6 +27,7 @@ pub struct DiscoverStageReport {
     pub cfg_pdg: StageTiming,
     pub cfg_taint: StageTiming,
     pub cfg_archive: StageTiming,
+    pub field_write: StageTiming,
     pub blast_build: StageTiming,
     pub blast_query: StageTiming,
     pub blast_snapshot: StageTiming,
@@ -57,6 +58,7 @@ impl DiscoverStageReport {
             + self.security.secs
             + self.cfg_total.secs
             + self.cfg_archive.secs
+            + self.field_write.secs
             + self.blast_build.secs
             + self.blast_query.secs
             + self.blast_snapshot.secs
@@ -78,6 +80,7 @@ impl DiscoverStageReport {
             ("security", self.security.secs),
             ("cfg_total", self.cfg_total.secs),
             ("cfg_archive", self.cfg_archive.secs),
+            ("field_write", self.field_write.secs),
             ("blast_build", self.blast_build.secs),
             ("blast_query", self.blast_query.secs),
             ("blast_snapshot", self.blast_snapshot.secs),

--- a/tests/csharp_cfg_analysis.rs
+++ b/tests/csharp_cfg_analysis.rs
@@ -3,14 +3,14 @@
 use rbuilder::analysis::{
     build_cfg_for_function, cfg_language_id_from_path, ProgramDependenceGraph,
 };
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-const CSHARP_REPO: &str = "/Users/sshaaf/git/rust/rbuilder-tests/ecommerce-csharp";
-
-fn csharp_repo() -> std::path::PathBuf {
+fn csharp_repo() -> PathBuf {
     std::env::var("RBUILDER_CSHARP_REPO")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|_| std::path::PathBuf::from(CSHARP_REPO))
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("rbuilder-tests/ecommerce-csharp")
+        })
 }
 
 #[test]

--- a/tests/go_langfeatures.rs
+++ b/tests/go_langfeatures.rs
@@ -1,0 +1,330 @@
+//! Go language-feature probes (LF-*) against ecommerce-go `internal/langfeatures`.
+//!
+//! See `docs/design/go-language-coverage.md` and issue #46.
+//!
+//! ```bash
+//! cargo test --test go_langfeatures -- --nocapture
+//! ```
+
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Once;
+
+fn repo() -> PathBuf {
+    if let Ok(p) = std::env::var("RBUILDER_GO_REPO") {
+        return PathBuf::from(p);
+    }
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("rbuilder-tests/ecommerce-go")
+}
+
+fn bin() -> PathBuf {
+    if let Ok(p) = std::env::var("CARGO_BIN_EXE_rbuilder") {
+        return PathBuf::from(p);
+    }
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/release/rbuilder")
+}
+
+fn ensure_discovered() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        let repo = repo();
+        if !repo.is_dir() {
+            return;
+        }
+        let _ = std::fs::remove_dir_all(repo.join(".rbuilder"));
+        let out = Command::new(bin())
+            .args(["discover", ".", "-l", "go", "-e", "vendor", "--with-cfg"])
+            .current_dir(&repo)
+            .output()
+            .expect("run discover");
+        assert!(
+            out.status.success(),
+            "discover failed:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    });
+}
+
+fn gql(repo: &Path, query: &str) -> Value {
+    let out = Command::new(bin())
+        .args(["-f", "json", "gql", query])
+        .current_dir(repo)
+        .output()
+        .expect("gql");
+    assert!(
+        out.status.success(),
+        "gql failed: {}\n{}",
+        query,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_slice(&out.stdout).expect("json")
+}
+
+fn callees_named(repo: &Path, caller: &str) -> Vec<(String, String)> {
+    let q = format!(
+        "MATCH (a:Function)-[:CALLS]->(b:Function) WHERE a.name = '{caller}' RETURN a,b"
+    );
+    let v = gql(repo, &q);
+    let mut out = Vec::new();
+    if let Some(rows) = v.get("rows").and_then(|r| r.as_array()) {
+        for row in rows {
+            let cells = row.as_array().cloned().unwrap_or_default();
+            let mut file = String::new();
+            let mut name = String::new();
+            for cell in cells {
+                if cell.get("binding").and_then(|b| b.as_str()) == Some("b") {
+                    name = cell
+                        .get("node")
+                        .and_then(|n| n.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    file = cell
+                        .get("file")
+                        .and_then(|n| n.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                }
+            }
+            if !name.is_empty() {
+                out.push((name, file));
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn lf01_package_call_edge() {
+    let repo = repo();
+    if !repo.is_dir() {
+        eprintln!("skip: missing {}", repo.display());
+        return;
+    }
+    ensure_discovered();
+    let callees = callees_named(&repo, "LfPkgCaller");
+    assert!(
+        callees.iter().any(|(n, _)| n == "LfPkgCallee"),
+        "LF-01 expected LfPkgCaller → LfPkgCallee, got {callees:?}"
+    );
+}
+
+#[test]
+fn lf02_same_type_method_call() {
+    let repo = repo();
+    if !repo.is_dir() {
+        return;
+    }
+    ensure_discovered();
+    let callees = callees_named(&repo, "Checkout");
+    assert!(
+        callees
+            .iter()
+            .any(|(n, f)| n == "validate" && f.contains("methods.go")),
+        "LF-02 expected Checkout → validate in methods.go, got {callees:?}"
+    );
+}
+
+#[test]
+fn lf03_cross_type_same_name_resolves_to_beta() {
+    let repo = repo();
+    if !repo.is_dir() {
+        return;
+    }
+    ensure_discovered();
+    let callees = callees_named(&repo, "Run");
+    assert!(
+        callees.iter().any(|(n, _)| n == "ListItems"),
+        "LF-03 expected Run → ListItems, got {callees:?}"
+    );
+    assert!(
+        !callees.iter().any(|(n, _)| n == "Run"),
+        "LF-03 must not self-loop Run → Run, got {callees:?}"
+    );
+}
+
+#[test]
+fn lf04_interface_method_call() {
+    let repo = repo();
+    if !repo.is_dir() {
+        return;
+    }
+    ensure_discovered();
+    let callees = callees_named(&repo, "Start");
+    assert!(
+        callees.iter().any(|(n, _)| n == "RunSandbox"),
+        "LF-04 expected Start → RunSandbox, got {callees:?}"
+    );
+}
+
+#[test]
+fn lf07_embed_promoted_method_call() {
+    let repo = repo();
+    if !repo.is_dir() {
+        return;
+    }
+    ensure_discovered();
+    let callees = callees_named(&repo, "UseBase");
+    assert!(
+        callees.iter().any(|(n, _)| n == "BaseMethod"),
+        "LF-07 expected UseBase → BaseMethod, got {callees:?}"
+    );
+}
+
+#[test]
+fn lf18_constructor_qualified_name() {
+    let repo = repo();
+    if !repo.is_dir() {
+        return;
+    }
+    ensure_discovered();
+    let out = Command::new(bin())
+        .args(["-f", "json", "blast-radius", "NewLfCart", "--depth", "1"])
+        .current_dir(&repo)
+        .output()
+        .expect("blast");
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let blast: Value = serde_json::from_slice(&out.stdout).unwrap();
+    let fqn = blast["target"]["canonical_fqn"].as_str().unwrap_or("");
+    assert!(
+        fqn == "LfCart.<init>" || fqn == "LfCart::<init>",
+        "LF-18 ctor FQN, got {fqn}"
+    );
+    let file = blast["target"]["file_path"].as_str().unwrap_or("");
+    assert!(
+        file.contains("methods.go"),
+        "LF-18 expected methods.go, got {file}"
+    );
+}
+
+fn node_names(v: &Value) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(rows) = v.get("rows").and_then(|r| r.as_array()) {
+        for row in rows {
+            let cells = row.as_array().cloned().unwrap_or_default();
+            for cell in cells {
+                if let Some(n) = cell.get("node").and_then(|n| n.as_str()) {
+                    out.push(n.to_string());
+                } else if let Some(n) = cell.as_str() {
+                    out.push(n.to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn lf05_implements_edges() {
+    let repo = repo();
+    if !repo.is_dir() {
+        return;
+    }
+    ensure_discovered();
+    let v = gql(
+        &repo,
+        "MATCH (a:Struct)-[:IMPLEMENTS]->(b:Interface) WHERE a.name = 'LfRemoteRuntime' RETURN a,b",
+    );
+    let names = node_names(&v);
+    assert!(
+        names.iter().any(|n| n == "LfRuntime"),
+        "LF-05 expected LfRemoteRuntime IMPLEMENTS LfRuntime, got {names:?} raw={v}"
+    );
+    let v2 = gql(
+        &repo,
+        "MATCH (a:Struct)-[:IMPLEMENTS]->(b:Interface) WHERE a.name = 'LfFakeRuntime' RETURN a,b",
+    );
+    let names2 = node_names(&v2);
+    assert!(
+        names2.iter().any(|n| n == "LfRuntime"),
+        "LF-05 expected LfFakeRuntime IMPLEMENTS LfRuntime, got {names2:?}"
+    );
+}
+
+#[test]
+fn lf06_embed_extends() {
+    let repo = repo();
+    if !repo.is_dir() {
+        return;
+    }
+    ensure_discovered();
+    let v = gql(
+        &repo,
+        "MATCH (a:Struct)-[:EXTENDS]->(b:Struct) WHERE a.name = 'LfDerived' RETURN a,b",
+    );
+    let names = node_names(&v);
+    assert!(
+        names.iter().any(|n| n == "LfBase"),
+        "LF-06 expected LfDerived EXTENDS LfBase, got {names:?}"
+    );
+}
+
+#[test]
+fn lf10_const_and_typealias() {
+    let repo = repo();
+    if !repo.is_dir() {
+        return;
+    }
+    ensure_discovered();
+    let consts = gql(
+        &repo,
+        "MATCH (n:Variable) WHERE n.name = 'LfStatusPending' RETURN n",
+    );
+    assert!(
+        !node_names(&consts).is_empty(),
+        "LF-10 expected Variable LfStatusPending"
+    );
+    let alias = gql(
+        &repo,
+        "MATCH (n:TypeAlias) WHERE n.name = 'LfUserID' RETURN n",
+    );
+    assert!(
+        !node_names(&alias).is_empty(),
+        "LF-10 expected TypeAlias LfUserID"
+    );
+}
+
+#[test]
+fn lf16_generics_symbols_present() {
+    let repo = repo();
+    if !repo.is_dir() {
+        return;
+    }
+    ensure_discovered();
+    let id = gql(
+        &repo,
+        "MATCH (n:Function) WHERE n.name = 'LfIdentity' RETURN n",
+    );
+    assert!(
+        !node_names(&id).is_empty(),
+        "LF-16 expected Function LfIdentity"
+    );
+    let box_t = gql(&repo, "MATCH (n:Struct) WHERE n.name = 'LfBox' RETURN n");
+    assert!(!node_names(&box_t).is_empty(), "LF-16 expected Struct LfBox");
+}
+
+#[test]
+fn lf17_import_symbols() {
+    let repo = repo();
+    if !repo.is_dir() {
+        return;
+    }
+    ensure_discovered();
+    let fmt = gql(&repo, "MATCH (n:Import) WHERE n.name = 'fmt' RETURN n");
+    assert!(
+        !node_names(&fmt).is_empty(),
+        "LF-17 expected Import fmt"
+    );
+    let tu = gql(
+        &repo,
+        "MATCH (n:Import) WHERE n.name = 'timeutil' RETURN n",
+    );
+    assert!(
+        !node_names(&tu).is_empty(),
+        "LF-17 expected Import timeutil"
+    );
+}

--- a/tests/graph_correctness_lib.rs
+++ b/tests/graph_correctness_lib.rs
@@ -381,6 +381,18 @@ fn symbol_candidates(m: &MatchSpec) -> Vec<String> {
 }
 
 fn run_blast(bin: &Path, cwd: &Path, m: &MatchSpec) -> Option<Value> {
+    // Go fixtures disambiguate by source file (`class: "methods.go"`).
+    if let Some(cls) = &m.class {
+        if cls.ends_with(".go") || cls.contains('/') {
+            if let Some(v) = run_json(
+                bin,
+                cwd,
+                &["-f", "json", "blast-radius", &m.name, "--file", cls],
+            ) {
+                return Some(v);
+            }
+        }
+    }
     for sym in symbol_candidates(m) {
         if let Some(v) = run_json(bin, cwd, &["-f", "json", "blast-radius", &sym]) {
             return Some(v);
@@ -393,6 +405,15 @@ fn run_inspect(bin: &Path, cwd: &Path, m: &MatchSpec, layer: &str) -> Option<Val
     for sym in symbol_candidates(m) {
         if let Some(v) = run_json(bin, cwd, &["-f", "json", "inspect", &sym, layer]) {
             return Some(v);
+        }
+    }
+    // Prefer FQN when class looks like a Go receiver/type name (not a filename).
+    if let Some(cls) = &m.class {
+        if !cls.ends_with(".go") && !cls.contains('/') {
+            let fqn = format!("{cls}.{}", m.name);
+            if let Some(v) = run_json(bin, cwd, &["-f", "json", "inspect", &fqn, layer]) {
+                return Some(v);
+            }
         }
     }
     None


### PR DESCRIPTION
  ## Summary
  - Fix Go call-graph gaps from #46: selector/`field_identifier` CALLS, receiver FQNs, interface method promotion,
  embeds → EXTENDS, IMPLEMENTS, imports/consts/aliases, `var_spec` def-use, switch/select complexity.
  - Expand shared `cfg_builder` lowering across Tier-1 languages (Go, Java, Rust, C, C++, C#) —
  foreach/switch/await/using, try/finally, match/`?`, coroutines, goto case, etc.
  - Harden ecommerce correctness CFG probes across languages; keep dashboard CFG schema unchanged.
  - Parallelize post-CFG field-write indexing (file-grouped Rayon + parse-once) — Kubernetes `field_write` ~550s →
  ~27.5s.
  ## Test plan
  - [x] `cargo test -p rbuilder-analysis --lib cfg_builder::tests`
  - [x] `cargo test -p rbuilder-analysis field_write`
  - [x] `cargo test --test go_langfeatures`
  - [x] `cargo test --test graph_correctness`
  - [x] Spot-check: `rbuilder -r example/kubernetes discover . -l go -e vendor,_output,bin,.git` then GQL
  `createPodSandbox` → `RunPodSandbox`
  - [x] Optional: `RUST_LOG=info,profile=info rbuilder discover . -v -l go -e vendor,_output,bin,.git --with-cfg`
  and confirm `[profile] stage="field_write"`