### PR TITLE
Add PHP Tier 1 language support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,43 +44,43 @@ edition = "2024"
 rust-version = "1.88"
 
 [workspace.dependencies]
-rgctl-plugin-api = { path = "crates/rgctl-plugin-api", version = "0.4.9" }
-rgctl-plugin-helpers = { path = "crates/rgctl-plugin-helpers", version = "0.4.9" }
-rgctl-config-formats = { path = "crates/rgctl-config-formats", version = "0.4.9" }
-rgctl-lang-runtime = { path = "crates/rgctl-lang-runtime", version = "0.4.9" }
-rgctl-registry = { path = "crates/rgctl-registry", version = "0.4.9" }
-rgctl-error = { path = "crates/rgctl-error", version = "0.4.9" }
-rgctl-graph = { path = "crates/rgctl-graph", version = "0.4.9" }
-rgctl-extraction = { path = "crates/rgctl-extraction", version = "0.4.9" }
-rgctl-pipeline = { path = "crates/rgctl-pipeline", version = "0.4.9" }
-rgctl-analysis = { path = "crates/rgctl-analysis", version = "0.4.9", default-features = false }
-rgctl-gql = { path = "crates/rgctl-gql", version = "0.4.9" }
-rgctl-export = { path = "crates/rgctl-export", version = "0.4.9" }
-rgctl-dashboard = { path = "crates/rgctl-dashboard", version = "0.4.9" }
-rgctl-wasm = { path = "crates/rgctl-wasm", version = "0.4.9" }
-rgctl-security = { path = "crates/rgctl-security", version = "0.4.9" }
-rgctl-project-config = { path = "crates/rgctl-project-config", version = "0.4.9" }
-rgctl-incremental = { path = "crates/rgctl-incremental", version = "0.4.9" }
-rgctl-semantic = { path = "crates/rgctl-semantic", version = "0.4.9" }
-rgctl-rules = { path = "crates/rgctl-rules", version = "0.4.9" }
-rgctl-kantra = { path = "crates/rgctl-kantra", version = "0.4.9" }
-rgctl-core = { path = "crates/rgctl-core", version = "0.4.9" }
-rgctl-service = { path = "crates/rgctl-service", version = "0.4.9" }
+rgctl-plugin-api = { path = "crates/rgctl-plugin-api", version = "0.4.10" }
+rgctl-plugin-helpers = { path = "crates/rgctl-plugin-helpers", version = "0.4.10" }
+rgctl-config-formats = { path = "crates/rgctl-config-formats", version = "0.4.10" }
+rgctl-lang-runtime = { path = "crates/rgctl-lang-runtime", version = "0.4.10" }
+rgctl-registry = { path = "crates/rgctl-registry", version = "0.4.10" }
+rgctl-error = { path = "crates/rgctl-error", version = "0.4.10" }
+rgctl-graph = { path = "crates/rgctl-graph", version = "0.4.10" }
+rgctl-extraction = { path = "crates/rgctl-extraction", version = "0.4.10" }
+rgctl-pipeline = { path = "crates/rgctl-pipeline", version = "0.4.10" }
+rgctl-analysis = { path = "crates/rgctl-analysis", version = "0.4.10", default-features = false }
+rgctl-gql = { path = "crates/rgctl-gql", version = "0.4.10" }
+rgctl-export = { path = "crates/rgctl-export", version = "0.4.10" }
+rgctl-dashboard = { path = "crates/rgctl-dashboard", version = "0.4.10" }
+rgctl-wasm = { path = "crates/rgctl-wasm", version = "0.4.10" }
+rgctl-security = { path = "crates/rgctl-security", version = "0.4.10" }
+rgctl-project-config = { path = "crates/rgctl-project-config", version = "0.4.10" }
+rgctl-incremental = { path = "crates/rgctl-incremental", version = "0.4.10" }
+rgctl-semantic = { path = "crates/rgctl-semantic", version = "0.4.10" }
+rgctl-rules = { path = "crates/rgctl-rules", version = "0.4.10" }
+rgctl-kantra = { path = "crates/rgctl-kantra", version = "0.4.10" }
+rgctl-core = { path = "crates/rgctl-core", version = "0.4.10" }
+rgctl-service = { path = "crates/rgctl-service", version = "0.4.10" }
 tempfile = "3"
 zstd = "0.13"
 rayon = "1.7"
-rgctl-lang-go = { path = "crates/rgctl-lang-go", version = "0.4.9" }
-rgctl-lang-java = { path = "crates/rgctl-lang-java", version = "0.4.9" }
-rgctl-lang-javascript = { path = "crates/rgctl-lang-javascript", version = "0.4.9" }
-rgctl-lang-python = { path = "crates/rgctl-lang-python", version = "0.4.9" }
-rgctl-lang-rust = { path = "crates/rgctl-lang-rust", version = "0.4.9" }
-rgctl-lang-typescript = { path = "crates/rgctl-lang-typescript", version = "0.4.9" }
-rgctl-lang-csharp = { path = "crates/rgctl-lang-csharp", version = "0.4.9" }
-rgctl-lang-c = { path = "crates/rgctl-lang-c", version = "0.4.9" }
-rgctl-lang-cpp = { path = "crates/rgctl-lang-cpp", version = "0.4.9" }
-rgctl-lang-markdown = { path = "crates/rgctl-lang-markdown", version = "0.4.9" }
-rgctl-lang-php = { path = "crates/rgctl-lang-php", version = "0.4.9" }
-rgctl-languages = { path = "crates/rgctl-languages", version = "0.4.9" }
+rgctl-lang-go = { path = "crates/rgctl-lang-go", version = "0.4.10" }
+rgctl-lang-java = { path = "crates/rgctl-lang-java", version = "0.4.10" }
+rgctl-lang-javascript = { path = "crates/rgctl-lang-javascript", version = "0.4.10" }
+rgctl-lang-python = { path = "crates/rgctl-lang-python", version = "0.4.10" }
+rgctl-lang-rust = { path = "crates/rgctl-lang-rust", version = "0.4.10" }
+rgctl-lang-typescript = { path = "crates/rgctl-lang-typescript", version = "0.4.10" }
+rgctl-lang-csharp = { path = "crates/rgctl-lang-csharp", version = "0.4.10" }
+rgctl-lang-c = { path = "crates/rgctl-lang-c", version = "0.4.10" }
+rgctl-lang-cpp = { path = "crates/rgctl-lang-cpp", version = "0.4.10" }
+rgctl-lang-markdown = { path = "crates/rgctl-lang-markdown", version = "0.4.10" }
+rgctl-lang-php = { path = "crates/rgctl-lang-php", version = "0.4.10" }
+rgctl-languages = { path = "crates/rgctl-languages", version = "0.4.10" }
 tree-sitter = "0.25"
 
 [workspace.lints.rust]
@@ -111,7 +111,7 @@ expect_used = "warn"
 
 [package]
 name = "rgctl"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["rgctl Contributors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "crates/rgctl-lang-c",
     "crates/rgctl-lang-cpp",
     "crates/rgctl-lang-markdown",
+    "crates/rgctl-lang-php",
     "crates/rgctl-languages",
 ]
 resolver = "2"
@@ -78,6 +79,7 @@ rgctl-lang-csharp = { path = "crates/rgctl-lang-csharp", version = "0.4.9" }
 rgctl-lang-c = { path = "crates/rgctl-lang-c", version = "0.4.9" }
 rgctl-lang-cpp = { path = "crates/rgctl-lang-cpp", version = "0.4.9" }
 rgctl-lang-markdown = { path = "crates/rgctl-lang-markdown", version = "0.4.9" }
+rgctl-lang-php = { path = "crates/rgctl-lang-php", version = "0.4.9" }
 rgctl-languages = { path = "crates/rgctl-languages", version = "0.4.9" }
 tree-sitter = "0.25"
 
@@ -333,6 +335,18 @@ path = "tests/dashboard_ecommerce_javascript.rs"
 [[test]]
 name = "dashboard_ecommerce_typescript"
 path = "tests/dashboard_ecommerce_typescript.rs"
+
+[[test]]
+name = "php_cfg_analysis"
+path = "tests/php_cfg_analysis.rs"
+
+[[test]]
+name = "php_taint"
+path = "tests/php_taint.rs"
+
+[[test]]
+name = "dashboard_ecommerce_php"
+path = "tests/dashboard_ecommerce_php.rs"
 
 [[test]]
 name = "js_taint"

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ rgctl ships with deep, enterprise-ready features for heavy modernization workloa
 | `check` | [§14 CI policy check](docs/user-guide.md#14-ci-policy-check) |
 | `serve` | [§15 HTTP server](docs/user-guide.md#15-http-server-serve--optional) |
 
-**Languages supported:** Nine Tier 1 languages (Rust, Python, Java, Go, TypeScript, JavaScript, C#, C, C++) plus config/IaC plugins and markdown. See [Languages](docs/languages.md) and [Markdown context](docs/markdown-context.md).
+**Languages supported:** Ten Tier 1 languages (Rust, Python, Java, Go, TypeScript, JavaScript, C#, C, C++, PHP) plus config/IaC plugins and markdown. See [Languages](docs/languages.md) and [Markdown context](docs/markdown-context.md).
 
 ---
 

--- a/crates/rgctl-analysis/Cargo.toml
+++ b/crates/rgctl-analysis/Cargo.toml
@@ -26,6 +26,7 @@ tree-sitter-c = "0.24"
 tree-sitter-cpp = "0.23.4"
 tree-sitter-javascript = "0.25"
 tree-sitter-typescript = "0.23"
+tree-sitter-php = "0.24.2"
 uuid = { version = "1", features = ["v4", "serde"] }
 bit-set = "0.8"
 tracing = "0.1"

--- a/crates/rgctl-analysis/Cargo.toml
+++ b/crates/rgctl-analysis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-analysis"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Graph analysis algorithms for rgctl"

--- a/crates/rgctl-analysis/src/cfg_builder.rs
+++ b/crates/rgctl-analysis/src/cfg_builder.rs
@@ -6474,4 +6474,32 @@ public class Printer {
             java_texts(&cfg)
         );
     }
+
+    #[test]
+    fn test_php_if_else_branching() {
+        let code = r#"<?php
+function example($x) {
+    if ($x > 0) {
+        return 1;
+    } else {
+        return 2;
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("php", code, "example").unwrap();
+        assert!(cfg.blocks.len() >= 4, "expected branching CFG for PHP if/else");
+    }
+
+    #[test]
+    fn test_php_foreach_cycle() {
+        let code = r#"<?php
+function example($items) {
+    foreach ($items as $item) {
+        process($item);
+    }
+}
+"#;
+        let cfg = build_cfg_for_function("php", code, "example").unwrap();
+        assert!(cfg.has_cycle(), "foreach must cycle");
+    }
 }

--- a/crates/rgctl-analysis/src/def_use.rs
+++ b/crates/rgctl-analysis/src/def_use.rs
@@ -308,16 +308,17 @@ fn collect_def_use(
         }
 
         // Shared identifiers
-        "identifier" | "shorthand_field_identifier" | "field_identifier" | "type_identifier" => {
+        "identifier" | "shorthand_field_identifier" | "field_identifier" | "type_identifier"
+        | "variable_name" => {
             if is_def_target {
                 if let Ok(name) = node.utf8_text(source) {
-                    if kind == "identifier" || kind == "shorthand_field_identifier" {
-                        defined.insert(name.to_string());
+                    if kind == "identifier" || kind == "shorthand_field_identifier" || kind == "variable_name" {
+                        defined.insert(name.trim_start_matches('$').to_string());
                     }
                 }
-            } else if kind == "identifier" || kind == "shorthand_field_identifier" {
+            } else if kind == "identifier" || kind == "shorthand_field_identifier" || kind == "variable_name" {
                 if let Ok(name) = node.utf8_text(source) {
-                    used.insert(name.to_string());
+                    used.insert(name.trim_start_matches('$').to_string());
                 }
             }
         }

--- a/crates/rgctl-analysis/src/field_write.rs
+++ b/crates/rgctl-analysis/src/field_write.rs
@@ -280,6 +280,9 @@ fn normalize_type_name(name: &str) -> String {
         .rsplit("::")
         .next()
         .unwrap_or(bare)
+        .rsplit('\\')
+        .next()
+        .unwrap_or(bare)
         .trim()
         .to_string()
 }
@@ -360,6 +363,7 @@ fn language_from_path(path: &str) -> String {
             "ts" | "tsx" => "typescript",
             "c" | "h" => "c",
             "cpp" | "cc" | "cxx" | "hpp" | "hh" => "cpp",
+            "php" => "php",
             _ => "unknown",
         })
         .unwrap_or("unknown")
@@ -384,7 +388,11 @@ fn extract_writes_from_cfg(
                 if member.is_empty() {
                     continue;
                 }
-                let receiver_type = type_env.get(receiver).cloned();
+                let receiver_key = receiver.trim_start_matches('$');
+                let receiver_type = type_env
+                    .get(receiver)
+                    .or_else(|| type_env.get(receiver_key))
+                    .cloned();
                 let kind = if receiver == "this" || receiver == "self" {
                     if receiver_type.is_some() {
                         FieldWriteKind::ThisField
@@ -968,6 +976,39 @@ function process(order) {
                 "process",
                 "process",
                 "order.js",
+                false,
+                vec![("order", "OrderDTO")],
+            ),
+            "OrderDTO",
+            "status",
+        );
+    }
+
+    #[test]
+    fn php_cfg_captures_field_write_and_query() {
+        let source = r#"<?php
+class OrderDTO {
+    public function __construct(private string $status) {}
+
+    public function getStatus(): string {
+        return $this->status;
+    }
+}
+
+function process(OrderDTO $order): void {
+    $order->status = "PROCESSED";
+}
+"#;
+        mutation_hit_helper(
+            "php",
+            source,
+            "__construct",
+            "process",
+            fn_node("__construct", "OrderDTO.<init>", "order.php", true, vec![]),
+            fn_node(
+                "process",
+                "process",
+                "order.php",
                 false,
                 vec![("order", "OrderDTO")],
             ),

--- a/crates/rgctl-analysis/src/field_write_locals.rs
+++ b/crates/rgctl-analysis/src/field_write_locals.rs
@@ -57,6 +57,7 @@ fn language_visit(language: &str) -> Option<(tree_sitter::Language, VisitFn)> {
         ),
         "c" => (tree_sitter_c::LANGUAGE.into(), visit_c_family),
         "cpp" => (tree_sitter_cpp::LANGUAGE.into(), visit_c_family),
+        "php" => (tree_sitter_php::LANGUAGE_PHP.into(), visit_php),
         _ => return None,
     })
 }
@@ -397,7 +398,6 @@ fn visit_python(
         now_in = name == function_name;
     }
     if now_in && matches!(kind, "typed_parameter" | "typed_default_parameter") {
-        // typed_parameter: identifier + type
         let mut name = None;
         let mut ty = None;
         let mut cursor = node.walk();
@@ -416,17 +416,9 @@ fn visit_python(
             insert_ty(env, &name, &ty);
         }
     }
-    if now_in && kind == "assignment" {
-        // `other: OrderDTO = order` — left may be typed via annotation sibling; skip untyped.
-        if let Some(left) = node.child_by_field_name("left") {
-            if left.kind() == "identifier" {
-                // look for type on annotated assignment: actually python uses `annotated_assignment`?
-            }
-        }
-    }
     if now_in && kind == "annotated_assignment" {
         let name = node
-            .child_by_field_name("left") // or name?
+            .child_by_field_name("left")
             .and_then(|n| text_of(n, source));
         let ty = node
             .child_by_field_name("type")
@@ -443,6 +435,65 @@ fn visit_python(
         now_in,
         visit_python,
         &["function_definition"],
+    );
+}
+
+fn visit_php(
+    node: Node,
+    source: &[u8],
+    function_name: &str,
+    env: &mut HashMap<String, String>,
+    in_target: bool,
+) {
+    let kind = node.kind();
+    let mut now_in = in_target;
+    if matches!(kind, "function_definition" | "method_declaration") {
+        let name = node
+            .child_by_field_name("name")
+            .and_then(|n| text_of(n, source))
+            .unwrap_or_default();
+        now_in = name == function_name;
+    }
+    if now_in
+        && matches!(
+            kind,
+            "simple_parameter" | "property_promotion_parameter" | "optional_parameter"
+        )
+    {
+        let name = node
+            .child_by_field_name("name")
+            .and_then(|n| text_of(n, source))
+            .map(|s| s.trim_start_matches('$').to_string());
+        let ty = node
+            .child_by_field_name("type")
+            .and_then(|n| text_of(n, source));
+        if let (Some(name), Some(ty)) = (name, ty) {
+            insert_ty(env, &name, &ty);
+        }
+    }
+    if now_in && kind == "assignment_expression" {
+        if let (Some(left), Some(right)) = (
+            node.child_by_field_name("left"),
+            node.child_by_field_name("right"),
+        ) {
+            if left.kind() == "variable_name" {
+                if let (Some(dst), Some(src)) = (text_of(left, source), text_of(right, source)) {
+                    let dst = dst.trim_start_matches('$');
+                    if let Some(ty) = env.get(&src.trim_start_matches('$').to_string()).cloned() {
+                        insert_ty(env, dst, &ty);
+                    }
+                }
+            }
+        }
+    }
+    walk_children(
+        node,
+        source,
+        function_name,
+        env,
+        now_in,
+        visit_php,
+        &["function_definition", "method_declaration"],
     );
 }
 

--- a/crates/rgctl-analysis/src/language_profile.rs
+++ b/crates/rgctl-analysis/src/language_profile.rs
@@ -114,6 +114,19 @@ const PROFILES: &[LanguageAnalysisProfile] = &[
         taint_enabled: true,
     },
     LanguageAnalysisProfile {
+        id: "php",
+        aliases: &[],
+        extensions: &["php"],
+        function_kinds: &[
+            "function_definition",
+            "method_declaration",
+            "arrow_function",
+            "anonymous_function",
+        ],
+        cfg_enabled: true,
+        taint_enabled: true,
+    },
+    LanguageAnalysisProfile {
         id: "ruby",
         aliases: &["rb"],
         extensions: &["rb"],
@@ -189,6 +202,7 @@ fn grammar_for(profile: &LanguageAnalysisProfile) -> Result<Language> {
         "cpp" => Ok(tree_sitter_cpp::LANGUAGE.into()),
         "javascript" => Ok(tree_sitter_javascript::LANGUAGE.into()),
         "typescript" => Ok(tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()),
+        "php" => Ok(tree_sitter_php::LANGUAGE_PHP.into()),
         other => Err(Error::UnsupportedLanguage(other.to_string())),
     }
 }

--- a/crates/rgctl-analysis/src/taint.rs
+++ b/crates/rgctl-analysis/src/taint.rs
@@ -566,7 +566,10 @@ impl<'a> TaintAnalyzer<'a> {
                 || text.contains("$_REQUEST")
                 || text.contains("$_COOKIE")
                 || text.contains("$_SERVER")
+                || text.contains("$_FILES")
                 || text.contains("php://input")
+                || text.contains("filter_input(")
+                || text.contains("filter_input_array(")
             {
                 self.sources.insert(*node_id, TaintSource::HttpParameter);
             } else if text.contains("file_get_contents(")
@@ -606,7 +609,7 @@ impl<'a> TaintAnalyzer<'a> {
 
             if text.contains("htmlspecialchars(") || text.contains("filter_var(") {
                 self.sanitizers.insert(*node_id, Sanitizer::HtmlEscape);
-            } else if text.contains("mysqli_real_escape_string(") {
+            } else if text.contains("mysqli_real_escape_string(") || text.contains("->prepare(") {
                 self.sanitizers.insert(*node_id, Sanitizer::SqlParameterize);
             }
         }

--- a/crates/rgctl-analysis/src/taint.rs
+++ b/crates/rgctl-analysis/src/taint.rs
@@ -157,6 +157,7 @@ impl<'a> TaintAnalyzer<'a> {
             "csharp" => self.detect_csharp_patterns(),
             "c" => self.detect_c_patterns(),
             "cpp" => self.detect_cpp_patterns(),
+            "php" => self.detect_php_patterns(),
             _ => {}
         }
     }
@@ -557,6 +558,60 @@ impl<'a> TaintAnalyzer<'a> {
         }
     }
 
+    fn detect_php_patterns(&mut self) {
+        for (node_id, node) in &self.pdg.nodes {
+            let text = &node.statement.text;
+            if text.contains("$_GET")
+                || text.contains("$_POST")
+                || text.contains("$_REQUEST")
+                || text.contains("$_COOKIE")
+                || text.contains("$_SERVER")
+                || text.contains("php://input")
+            {
+                self.sources.insert(*node_id, TaintSource::HttpParameter);
+            } else if text.contains("file_get_contents(")
+                || text.contains("fgets(")
+                || text.contains("readfile(")
+                || text.contains("fopen(")
+            {
+                self.sources.insert(*node_id, TaintSource::FileInput);
+            }
+
+            if text.contains("mysqli_query(")
+                || text.contains("mysql_query(")
+                || text.contains("->query(")
+                || text.contains("->exec(")
+            {
+                self.sinks.insert(*node_id, TaintSink::SqlQuery);
+            } else if text.contains("exec(")
+                || text.contains("shell_exec(")
+                || text.contains("system(")
+                || text.contains("passthru(")
+                || text.contains("proc_open(")
+            {
+                self.sinks.insert(*node_id, TaintSink::ShellCommand);
+            } else if text.contains("eval(") || text.contains("assert(") {
+                self.sinks.insert(*node_id, TaintSink::CodeEval);
+            } else if text.contains("include(")
+                || text.contains("require(")
+                || text.contains("include_once(")
+                || text.contains("require_once(")
+            {
+                self.sinks.insert(*node_id, TaintSink::FileWrite);
+            } else if text.contains("unserialize(") {
+                self.sinks.insert(*node_id, TaintSink::CodeEval);
+            } else if text.contains("echo ") || text.contains("print ") {
+                self.sinks.insert(*node_id, TaintSink::HtmlRender);
+            }
+
+            if text.contains("htmlspecialchars(") || text.contains("filter_var(") {
+                self.sanitizers.insert(*node_id, Sanitizer::HtmlEscape);
+            } else if text.contains("mysqli_real_escape_string(") {
+                self.sanitizers.insert(*node_id, Sanitizer::SqlParameterize);
+            }
+        }
+    }
+
     /// Run forward taint analysis.
     pub fn analyze(&self) -> Vec<TaintFlow> {
         let mut flows = Vec::new();
@@ -795,6 +850,25 @@ def handle_request(request):
         analyzer.detect_patterns("python");
         let flows = analyzer.vulnerable_flows();
         assert!(!flows.is_empty(), "expected vulnerable SQL flow");
+        assert_eq!(flows[0].source_type, TaintSource::HttpParameter);
+        assert_eq!(flows[0].sink_type, TaintSink::SqlQuery);
+    }
+
+    #[test]
+    fn test_taint_sql_injection_php() {
+        let code = r#"<?php
+function handle_request() {
+    $username = $_GET['username'];
+    $query = "SELECT * FROM users WHERE name = '" . $username . "'";
+    mysqli_query($conn, $query);
+}
+"#;
+        let cfg = build_cfg_for_function("php", code, "handle_request").unwrap();
+        let pdg = ProgramDependenceGraph::build(&cfg, code.as_bytes()).unwrap();
+        let mut analyzer = TaintAnalyzer::new(&pdg, &cfg);
+        analyzer.detect_patterns("php");
+        let flows = analyzer.vulnerable_flows();
+        assert!(!flows.is_empty(), "expected vulnerable PHP SQL flow");
         assert_eq!(flows[0].source_type, TaintSource::HttpParameter);
         assert_eq!(flows[0].sink_type, TaintSink::SqlQuery);
     }

--- a/crates/rgctl-config-formats/Cargo.toml
+++ b/crates/rgctl-config-formats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-config-formats"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Configuration format plugins for rgctl"

--- a/crates/rgctl-core/Cargo.toml
+++ b/crates/rgctl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-core"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Facade crate for rgctl library consumers"

--- a/crates/rgctl-dashboard/Cargo.toml
+++ b/crates/rgctl-dashboard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-dashboard"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Static dashboard bundle export for rgctl"

--- a/crates/rgctl-error/Cargo.toml
+++ b/crates/rgctl-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-error"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Error types for rgctl"

--- a/crates/rgctl-export/Cargo.toml
+++ b/crates/rgctl-export/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-export"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Graph export and visualization for rgctl"

--- a/crates/rgctl-extraction/Cargo.toml
+++ b/crates/rgctl-extraction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-extraction"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Code extraction layer for rgctl"

--- a/crates/rgctl-gql/Cargo.toml
+++ b/crates/rgctl-gql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-gql"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Graph query language for rgctl"

--- a/crates/rgctl-graph/Cargo.toml
+++ b/crates/rgctl-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-graph"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Graph storage and query layer for rgctl"

--- a/crates/rgctl-incremental/Cargo.toml
+++ b/crates/rgctl-incremental/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-incremental"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Incremental graph updates for rgctl"

--- a/crates/rgctl-kantra/Cargo.toml
+++ b/crates/rgctl-kantra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-kantra"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Native Konveyor Kantra rule evaluator for rgctl"

--- a/crates/rgctl-lang-c/Cargo.toml
+++ b/crates/rgctl-lang-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-lang-c"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "rgctl language plugin: c"

--- a/crates/rgctl-lang-cpp/Cargo.toml
+++ b/crates/rgctl-lang-cpp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-lang-cpp"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "rgctl language plugin: cpp"

--- a/crates/rgctl-lang-csharp/Cargo.toml
+++ b/crates/rgctl-lang-csharp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-lang-csharp"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "rgctl language plugin: csharp"

--- a/crates/rgctl-lang-go/Cargo.toml
+++ b/crates/rgctl-lang-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-lang-go"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "rgctl language plugin: go"

--- a/crates/rgctl-lang-java/Cargo.toml
+++ b/crates/rgctl-lang-java/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-lang-java"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "rgctl language plugin: java"

--- a/crates/rgctl-lang-javascript/Cargo.toml
+++ b/crates/rgctl-lang-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-lang-javascript"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "rgctl language plugin: javascript"

--- a/crates/rgctl-lang-markdown/Cargo.toml
+++ b/crates/rgctl-lang-markdown/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-lang-markdown"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "rgctl language plugin: markdown (context / documentation graph)"

--- a/crates/rgctl-lang-php/Cargo.toml
+++ b/crates/rgctl-lang-php/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "rgctl-lang-php"
+version = "0.4.9"
+edition.workspace = true
+rust-version.workspace = true
+description = "rgctl language plugin: php"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+rgctl-plugin-api = { workspace = true }
+rgctl-registry = { workspace = true }
+rgctl-plugin-helpers = { workspace = true }
+tree-sitter = { workspace = true }
+tree-sitter-php = "0.24.2"
+serde_json = "1"
+tracing = "0.1"

--- a/crates/rgctl-lang-php/Cargo.toml
+++ b/crates/rgctl-lang-php/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-lang-php"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "rgctl language plugin: php"

--- a/crates/rgctl-lang-php/src/lib.rs
+++ b/crates/rgctl-lang-php/src/lib.rs
@@ -1,7 +1,10 @@
 //! PHP language plugin for rgctl (Tier 1).
 //!
-//! Honesty limits: no `include`/`require` resolution, no trait linearization,
-//! no magic-method dispatch (`__call`, `__get`), best-effort dynamic call targets.
+//! Honesty limits: no `include`/`require` resolution, no trait linearization or
+//! `insteadof` alias precedence, no magic-method dispatch (`__call`, `__get`),
+//! best-effort dynamic call targets (`metadata.unresolved`), no assignment tracking
+//! for first-class callables beyond direct patterns, no Composer autoload graph.
+//! Set `RGCTL_PHP_ONLY=1` to parse `.php` with `LANGUAGE_PHP_ONLY` (pure PHP, no HTML).
 
 use rgctl_registry::LanguageRegistry;
 use std::sync::Arc;

--- a/crates/rgctl-lang-php/src/lib.rs
+++ b/crates/rgctl-lang-php/src/lib.rs
@@ -1,0 +1,15 @@
+//! PHP language plugin for rgctl (Tier 1).
+//!
+//! Honesty limits: no `include`/`require` resolution, no trait linearization,
+//! no magic-method dispatch (`__call`, `__get`), best-effort dynamic call targets.
+
+use rgctl_registry::LanguageRegistry;
+use std::sync::Arc;
+
+mod plugin;
+pub use plugin::PhpPlugin;
+
+/// Register the PHP language plugin.
+pub fn register(registry: &mut LanguageRegistry) {
+    registry.register_language_plugin(Arc::new(PhpPlugin::new().expect("init PhpPlugin")));
+}

--- a/crates/rgctl-lang-php/src/plugin.rs
+++ b/crates/rgctl-lang-php/src/plugin.rs
@@ -1,0 +1,930 @@
+//! PHP language plugin using Tree-sitter.
+
+use rgctl_plugin_api::{PHP_CALL_KINDS, *};
+use rgctl_plugin_helpers::ComplexityCalculator;
+use std::path::Path;
+use tree_sitter::{Node, Parser};
+
+pub const PHP_FUNCTION_KINDS: &[&str] = &[
+    "function_definition",
+    "method_declaration",
+    "arrow_function",
+    "anonymous_function",
+];
+
+const PHP_COMPLEXITY_BRANCH_KINDS: &[&str] = &[
+    "if_statement",
+    "else_if_clause",
+    "while_statement",
+    "for_statement",
+    "foreach_statement",
+    "switch_statement",
+    "match_expression",
+    "catch_clause",
+];
+
+/// PHP Tier 1 language plugin.
+pub struct PhpPlugin {
+    _parser: Parser,
+}
+
+impl PhpPlugin {
+    /// Create a new PHP plugin.
+    pub fn new() -> Result<Self> {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_php::LANGUAGE_PHP.into())
+            .map_err(|e| Error::PluginError(format!("Failed to set PHP grammar: {e}")))?;
+        Ok(Self { _parser: parser })
+    }
+
+    fn parse(&self, file_path: &Path, source: &[u8]) -> Result<tree_sitter::Tree> {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_php::LANGUAGE_PHP.into())
+            .map_err(|e| Error::PluginError(format!("Failed to set PHP grammar: {e}")))?;
+        parser.parse(source, None).ok_or_else(|| Error::ParseError {
+            file: file_path.to_path_buf(),
+            line: 0,
+            message: "Failed to parse PHP source".to_string(),
+        })
+    }
+
+    fn symbols_from_tree(
+        &self,
+        root: Node,
+        source: &[u8],
+        file_path: &Path,
+    ) -> Result<Vec<Symbol>> {
+        let mut symbols = Vec::new();
+        let mut namespace = None;
+        let file_path_str = file_path.to_string_lossy();
+        self.traverse_symbols(
+            root,
+            source,
+            &file_path_str,
+            &mut namespace,
+            &mut symbols,
+        )?;
+        Ok(symbols)
+    }
+
+    fn traverse_symbols(
+        &self,
+        node: Node,
+        source: &[u8],
+        file_path: &str,
+        namespace: &mut Option<String>,
+        symbols: &mut Vec<Symbol>,
+    ) -> Result<()> {
+        if node.kind() == "namespace_definition" {
+            if let Some(ns) = node
+                .child_by_field_name("name")
+                .and_then(|n| normalize_namespace(n, source))
+            {
+                *namespace = Some(ns);
+            }
+        }
+
+        match node.kind() {
+            "function_definition" => {
+                if let Some(sym) =
+                    self.extract_function(node, source, file_path, namespace.as_deref())?
+                {
+                    symbols.push(sym);
+                }
+            }
+            "method_declaration" => {
+                if self.find_enclosing_class_name(node, source).is_none() {
+                    if let Some(sym) =
+                        self.extract_method(node, source, file_path, namespace.as_deref(), None)?
+                    {
+                        symbols.push(sym);
+                    }
+                }
+            }
+            "arrow_function" | "anonymous_function" => {
+                if let Some(sym) =
+                    self.extract_anonymous_function(node, source, file_path, namespace.as_deref())?
+                {
+                    symbols.push(sym);
+                }
+            }
+            "class_declaration" => {
+                symbols.push(self.extract_class(node, source, file_path, namespace.as_deref())?);
+                self.traverse_class_members(node, source, file_path, namespace.as_deref(), symbols)?;
+            }
+            "interface_declaration" => {
+                symbols.push(self.extract_interface(node, source, file_path, namespace.as_deref())?);
+            }
+            "trait_declaration" => {
+                symbols.push(self.extract_trait(node, source, file_path, namespace.as_deref())?);
+            }
+            "enum_declaration" => {
+                symbols.push(self.extract_enum(node, source, file_path, namespace.as_deref())?);
+            }
+            _ => {
+                let mut cursor = node.walk();
+                for child in node.children(&mut cursor) {
+                    self.traverse_symbols(child, source, file_path, namespace, symbols)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn traverse_class_members(
+        &self,
+        class_node: Node,
+        source: &[u8],
+        file_path: &str,
+        namespace: Option<&str>,
+        symbols: &mut Vec<Symbol>,
+    ) -> Result<()> {
+        let class_name = type_name(class_node, source).unwrap_or_default();
+        let qclass = qualify(namespace, &class_name);
+        let body = class_node
+            .child_by_field_name("body")
+            .or_else(|| find_child_kind(class_node, "declaration_list"));
+        let Some(body) = body else {
+            return Ok(());
+        };
+
+        let mut cursor = body.walk();
+        for child in body.children(&mut cursor) {
+            if child.kind() == "method_declaration" {
+                if let Some(sym) = self.extract_method(
+                    child,
+                    source,
+                    file_path,
+                    namespace,
+                    Some(qclass.as_str()),
+                )? {
+                    symbols.push(sym);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn extract_function(
+        &self,
+        node: Node,
+        source: &[u8],
+        file_path: &str,
+        namespace: Option<&str>,
+    ) -> Result<Option<Symbol>> {
+        let name = node_name(node, source).ok_or_else(|| Error::ParseError {
+            file: file_path.into(),
+            line: node.start_position().row + 1,
+            message: "Function missing name".to_string(),
+        })?;
+        let parameters = self.extract_parameters(node, source)?;
+        let return_type = node
+            .child_by_field_name("return_type")
+            .and_then(|n| n.utf8_text(source).ok())
+            .map(str::to_string);
+        let qualified_name = qualify(namespace, &name);
+        Ok(Some(Symbol {
+            name,
+            symbol_type: SymbolType::Function,
+            qualified_name: Some(qualified_name),
+            location: source_location(node, file_path),
+            signature: Some(first_line(node, source)),
+            return_type,
+            parameters,
+            fields: vec![],
+            modifiers: visibility_modifiers(node, source),
+            documentation: None,
+            metadata: serde_json::json!({ "language": "php" }),
+        }))
+    }
+
+    fn extract_method(
+        &self,
+        node: Node,
+        source: &[u8],
+        file_path: &str,
+        namespace: Option<&str>,
+        enclosing_class: Option<&str>,
+    ) -> Result<Option<Symbol>> {
+        let name = node_name(node, source).ok_or_else(|| Error::ParseError {
+            file: file_path.into(),
+            line: node.start_position().row + 1,
+            message: "Method missing name".to_string(),
+        })?;
+
+        let class_name = enclosing_class
+            .map(str::to_string)
+            .or_else(|| self.find_enclosing_class_name(node, source));
+        let parameters = self.extract_parameters(node, source)?;
+        let return_type = node
+            .child_by_field_name("return_type")
+            .and_then(|n| n.utf8_text(source).ok())
+            .map(str::to_string);
+
+        let is_constructor = name == "__construct";
+        let qualified_name = if is_constructor {
+            class_name
+                .as_ref()
+                .map(|c| format!("{c}.<init>"))
+                .or_else(|| Some(format!("{}.<init>", name)))
+        } else {
+            class_name
+                .as_ref()
+                .map(|c| format!("{c}.{name}"))
+                .or_else(|| Some(qualify(namespace, &name)))
+        };
+
+        let mut metadata = serde_json::json!({ "language": "php" });
+        if is_constructor {
+            metadata["is_constructor"] = serde_json::json!(true);
+        }
+
+        Ok(Some(Symbol {
+            name: name.clone(),
+            symbol_type: SymbolType::Function,
+            qualified_name,
+            location: source_location(node, file_path),
+            signature: Some(first_line(node, source)),
+            return_type,
+            parameters,
+            fields: vec![],
+            modifiers: visibility_modifiers(node, source),
+            documentation: None,
+            metadata,
+        }))
+    }
+
+    fn extract_anonymous_function(
+        &self,
+        node: Node,
+        source: &[u8],
+        file_path: &str,
+        namespace: Option<&str>,
+    ) -> Result<Option<Symbol>> {
+        let line = node.start_position().row + 1;
+        let name = if node.kind() == "arrow_function" {
+            format!("$arrow${line}")
+        } else {
+            format!("$anonymous${line}")
+        };
+        let parameters = self.extract_parameters(node, source)?;
+        let return_type = node
+            .child_by_field_name("return_type")
+            .and_then(|n| n.utf8_text(source).ok())
+            .map(str::to_string);
+        Ok(Some(Symbol {
+            name: name.clone(),
+            symbol_type: SymbolType::Function,
+            qualified_name: Some(qualify(namespace, &name)),
+            location: source_location(node, file_path),
+            signature: Some(first_line(node, source)),
+            return_type,
+            parameters,
+            fields: vec![],
+            modifiers: vec![],
+            documentation: None,
+            metadata: serde_json::json!({ "language": "php", "is_anonymous": true }),
+        }))
+    }
+
+    fn extract_class(
+        &self,
+        node: Node,
+        source: &[u8],
+        file_path: &str,
+        namespace: Option<&str>,
+    ) -> Result<Symbol> {
+        let name = type_name(node, source).ok_or_else(|| Error::ParseError {
+            file: file_path.into(),
+            line: node.start_position().row + 1,
+            message: "Class missing name".to_string(),
+        })?;
+        let fields = self.extract_type_fields(node, source)?;
+        Ok(Symbol {
+            name: name.clone(),
+            symbol_type: SymbolType::Class,
+            qualified_name: Some(qualify(namespace, &name)),
+            location: source_location(node, file_path),
+            signature: None,
+            return_type: None,
+            parameters: vec![],
+            fields,
+            modifiers: visibility_modifiers(node, source),
+            documentation: None,
+            metadata: serde_json::json!({ "language": "php" }),
+        })
+    }
+
+    fn extract_interface(
+        &self,
+        node: Node,
+        source: &[u8],
+        file_path: &str,
+        namespace: Option<&str>,
+    ) -> Result<Symbol> {
+        let name = type_name(node, source).ok_or_else(|| Error::ParseError {
+            file: file_path.into(),
+            line: node.start_position().row + 1,
+            message: "Interface missing name".to_string(),
+        })?;
+        Ok(Symbol {
+            name: name.clone(),
+            symbol_type: SymbolType::Interface,
+            qualified_name: Some(qualify(namespace, &name)),
+            location: source_location(node, file_path),
+            signature: None,
+            return_type: None,
+            parameters: vec![],
+            fields: vec![],
+            modifiers: visibility_modifiers(node, source),
+            documentation: None,
+            metadata: serde_json::json!({ "language": "php" }),
+        })
+    }
+
+    fn extract_trait(
+        &self,
+        node: Node,
+        source: &[u8],
+        file_path: &str,
+        namespace: Option<&str>,
+    ) -> Result<Symbol> {
+        let name = type_name(node, source).ok_or_else(|| Error::ParseError {
+            file: file_path.into(),
+            line: node.start_position().row + 1,
+            message: "Trait missing name".to_string(),
+        })?;
+        Ok(Symbol {
+            name: name.clone(),
+            symbol_type: SymbolType::Class,
+            qualified_name: Some(qualify(namespace, &name)),
+            location: source_location(node, file_path),
+            signature: None,
+            return_type: None,
+            parameters: vec![],
+            fields: vec![],
+            modifiers: visibility_modifiers(node, source),
+            documentation: None,
+            metadata: serde_json::json!({ "language": "php", "is_trait": true }),
+        })
+    }
+
+    fn extract_enum(
+        &self,
+        node: Node,
+        source: &[u8],
+        file_path: &str,
+        namespace: Option<&str>,
+    ) -> Result<Symbol> {
+        let name = type_name(node, source).ok_or_else(|| Error::ParseError {
+            file: file_path.into(),
+            line: node.start_position().row + 1,
+            message: "Enum missing name".to_string(),
+        })?;
+        Ok(Symbol {
+            name: name.clone(),
+            symbol_type: SymbolType::Enum,
+            qualified_name: Some(qualify(namespace, &name)),
+            location: source_location(node, file_path),
+            signature: None,
+            return_type: None,
+            parameters: vec![],
+            fields: vec![],
+            modifiers: visibility_modifiers(node, source),
+            documentation: None,
+            metadata: serde_json::json!({ "language": "php" }),
+        })
+    }
+
+    fn extract_type_fields(&self, type_node: Node, source: &[u8]) -> Result<Vec<Field>> {
+        let mut fields = Vec::new();
+        let body = type_node
+            .child_by_field_name("body")
+            .or_else(|| find_child_kind(type_node, "declaration_list"));
+        let Some(body) = body else {
+            return Ok(fields);
+        };
+
+        let mut body_cursor = body.walk();
+        for child in body.children(&mut body_cursor) {
+            if child.kind() == "property_declaration" {
+                let field_type = child
+                    .child_by_field_name("type")
+                    .and_then(|n| n.utf8_text(source).ok())
+                    .map(str::to_string);
+                let visibility = visibility_modifiers(child, source).join(" ");
+                let vis = if visibility.is_empty() {
+                    None
+                } else {
+                    Some(visibility)
+                };
+                let mut elem_cursor = child.walk();
+                for elem in child.children(&mut elem_cursor) {
+                    if elem.kind() != "property_element" {
+                        continue;
+                    }
+                    if let Some(name_node) = elem.child_by_field_name("name") {
+                        if let Some(name) = variable_text(name_node, source) {
+                            fields.push(Field {
+                                name,
+                                field_type: field_type.clone(),
+                                visibility: vis.clone(),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        let body = type_node
+            .child_by_field_name("body")
+            .or_else(|| find_child_kind(type_node, "declaration_list"));
+        if let Some(body) = body {
+            let mut body_cursor = body.walk();
+            for child in body.children(&mut body_cursor) {
+                if child.kind() == "method_declaration" {
+                    if node_name(child, source).as_deref() == Some("__construct") {
+                        if let Some(params) = child.child_by_field_name("parameters") {
+                            self.collect_promoted_fields(params, source, &mut fields)?;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(fields)
+    }
+
+    fn collect_promoted_fields(
+        &self,
+        params_node: Node,
+        source: &[u8],
+        fields: &mut Vec<Field>,
+    ) -> Result<()> {
+        let mut cursor = params_node.walk();
+        for child in params_node.children(&mut cursor) {
+            if child.kind() != "property_promotion_parameter" {
+                continue;
+            }
+            let name = child
+                .child_by_field_name("name")
+                .and_then(|n| variable_text(n, source));
+            let field_type = child
+                .child_by_field_name("type")
+                .and_then(|n| n.utf8_text(source).ok())
+                .map(str::to_string);
+            let visibility = visibility_modifiers(child, source).join(" ");
+            if let Some(name) = name {
+                fields.push(Field {
+                    name,
+                    field_type,
+                    visibility: if visibility.is_empty() {
+                        None
+                    } else {
+                        Some(visibility)
+                    },
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn extract_parameters(&self, node: Node, source: &[u8]) -> Result<Vec<Parameter>> {
+        let mut parameters = Vec::new();
+        let Some(params_node) = node.child_by_field_name("parameters") else {
+            return Ok(parameters);
+        };
+
+        let mut cursor = params_node.walk();
+        for child in params_node.children(&mut cursor) {
+            match child.kind() {
+                "simple_parameter" | "property_promotion_parameter" | "optional_parameter"
+                | "variadic_parameter" => {
+                    let name = child
+                        .child_by_field_name("name")
+                        .and_then(|n| variable_text(n, source));
+                    let param_type = child
+                        .child_by_field_name("type")
+                        .and_then(|n| n.utf8_text(source).ok())
+                        .map(str::to_string);
+                    let default_value = child
+                        .child_by_field_name("default_value")
+                        .and_then(|n| n.utf8_text(source).ok())
+                        .map(str::to_string);
+                    if let Some(name) = name {
+                        parameters.push(Parameter {
+                            name,
+                            param_type,
+                            default_value,
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(parameters)
+    }
+
+    fn find_enclosing_class_name(&self, node: Node, source: &[u8]) -> Option<String> {
+        let mut current = node;
+        while let Some(parent) = current.parent() {
+            if parent.kind() == "class_declaration" {
+                return type_name(parent, source);
+            }
+            current = parent;
+        }
+        None
+    }
+
+    fn relations_from_tree(
+        &self,
+        root: Node,
+        source: &[u8],
+        file_path: &Path,
+        symbols: &[Symbol],
+    ) -> Result<Vec<Relation>> {
+        let mut relations = Vec::new();
+        walk_calls(
+            root,
+            source,
+            file_path,
+            symbols,
+            PHP_CALL_KINDS,
+            "php",
+            &mut relations,
+        );
+        self.extract_inheritance(root, source, file_path, &mut relations)?;
+        Ok(relations)
+    }
+
+    fn extract_inheritance(
+        &self,
+        node: Node,
+        source: &[u8],
+        file_path: &Path,
+        relations: &mut Vec<Relation>,
+    ) -> Result<()> {
+        if node.kind() == "class_declaration" {
+            let name = type_name(node, source).unwrap_or_default();
+            if !name.is_empty() {
+                let mut cursor = node.walk();
+                for child in node.children(&mut cursor) {
+                    match child.kind() {
+                        "base_clause" => {
+                            for base in type_refs(child, source) {
+                                relations.push(relation(
+                                    &name,
+                                    &base,
+                                    RelationType::Extends,
+                                    child,
+                                    file_path,
+                                ));
+                            }
+                        }
+                        "class_interface_clause" => {
+                            for iface in type_refs(child, source) {
+                                relations.push(relation(
+                                    &name,
+                                    &iface,
+                                    RelationType::Implements,
+                                    child,
+                                    file_path,
+                                ));
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.extract_inheritance(child, source, file_path, relations)?;
+        }
+        Ok(())
+    }
+}
+
+impl Default for PhpPlugin {
+    fn default() -> Self {
+        Self::new().expect("Failed to create PhpPlugin")
+    }
+}
+
+impl LanguagePlugin for PhpPlugin {
+    fn language_id(&self) -> &str {
+        "php"
+    }
+
+    fn file_extensions(&self) -> Vec<&str> {
+        vec!["php"]
+    }
+
+    fn grammar(&self) -> Option<tree_sitter::Language> {
+        Some(tree_sitter_php::LANGUAGE_PHP.into())
+    }
+
+    fn extract_symbols(&self, file_path: &Path, source: &[u8]) -> Result<Vec<Symbol>> {
+        let tree = self.parse(file_path, source)?;
+        self.symbols_from_tree(tree.root_node(), source, file_path)
+    }
+
+    fn extract_relations(
+        &self,
+        file_path: &Path,
+        source: &[u8],
+        symbols: &[Symbol],
+    ) -> Result<Vec<Relation>> {
+        let tree = self.parse(file_path, source)?;
+        self.relations_from_tree(tree.root_node(), source, file_path, symbols)
+    }
+
+    fn extract_all(&self, file_path: &Path, source: &[u8]) -> Result<ExtractAllResult> {
+        let tree = self.parse(file_path, source)?;
+        let root = tree.root_node();
+        let symbols = self.symbols_from_tree(root, source, file_path)?;
+        let relations = self.relations_from_tree(root, source, file_path, &symbols)?;
+        Ok(ExtractAllResult::from_parts(symbols, relations))
+    }
+
+    fn calculate_complexity(
+        &self,
+        symbol: &Symbol,
+        source: &[u8],
+    ) -> Result<Option<ComplexityMetrics>> {
+        if symbol.symbol_type != SymbolType::Function {
+            return Ok(None);
+        }
+
+        let tree = self.parse(Path::new(&symbol.location.file), source)?;
+        let target_line = symbol.location.start_line.saturating_sub(1);
+        let kinds: Vec<&str> = PHP_FUNCTION_KINDS.to_vec();
+
+        if let Some(func_node) = find_node_at_line(tree.root_node(), target_line, &kinds) {
+            Ok(Some(ComplexityMetrics {
+                cyclomatic: ComplexityCalculator::cyclomatic(func_node, PHP_COMPLEXITY_BRANCH_KINDS),
+                cognitive: ComplexityCalculator::cognitive(func_node, PHP_COMPLEXITY_BRANCH_KINDS),
+                loc: ComplexityCalculator::loc(func_node),
+                parameters: symbol.parameters.len(),
+                nesting_depth: ComplexityCalculator::nesting_depth(
+                    func_node,
+                    &["compound_statement", "declaration_list"],
+                ),
+                returns: ComplexityCalculator::return_count(func_node, "return_statement"),
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+fn find_node_at_line<'a>(node: Node<'a>, line: usize, kinds: &[&str]) -> Option<Node<'a>> {
+    if kinds.contains(&node.kind()) && node.start_position().row == line {
+        return Some(node);
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if let Some(found) = find_node_at_line(child, line, kinds) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn qualify(namespace: Option<&str>, name: &str) -> String {
+    match namespace {
+        Some(ns) if !ns.is_empty() => format!("{ns}\\{name}"),
+        _ => name.to_string(),
+    }
+}
+
+fn normalize_namespace(node: Node, source: &[u8]) -> Option<String> {
+    let text = node.utf8_text(source).ok()?;
+    Some(text.trim().trim_start_matches('\\').to_string())
+}
+
+fn type_name(node: Node, source: &[u8]) -> Option<String> {
+    node.child_by_field_name("name")
+        .and_then(|n| n.utf8_text(source).ok())
+        .map(|s| s.trim_start_matches('\\').to_string())
+}
+
+fn node_name(node: Node, source: &[u8]) -> Option<String> {
+    node.child_by_field_name("name")
+        .and_then(|n| n.utf8_text(source).ok())
+        .map(str::to_string)
+}
+
+fn variable_text(node: Node, source: &[u8]) -> Option<String> {
+    node.utf8_text(source)
+        .ok()
+        .map(|s| s.trim_start_matches('$').to_string())
+}
+
+fn visibility_modifiers(node: Node, source: &[u8]) -> Vec<String> {
+    let mut mods = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "visibility_modifier"
+            || child.kind() == "static_modifier"
+            || child.kind() == "abstract_modifier"
+            || child.kind() == "final_modifier"
+            || child.kind() == "readonly_modifier"
+        {
+            if let Ok(text) = child.utf8_text(source) {
+                mods.push(text.to_string());
+            }
+        }
+    }
+    mods
+}
+
+fn type_refs(node: Node, source: &[u8]) -> Vec<String> {
+    let mut refs = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if matches!(
+            child.kind(),
+            "name" | "qualified_name" | "relative_name"
+        ) {
+            if let Ok(text) = child.utf8_text(source) {
+                refs.push(text.trim_start_matches('\\').to_string());
+            }
+        }
+    }
+    refs
+}
+
+fn find_child_kind<'a>(node: Node<'a>, kind: &str) -> Option<Node<'a>> {
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .find(|c| c.kind() == kind)
+}
+
+fn source_location(node: Node, file_path: &str) -> SourceLocation {
+    SourceLocation {
+        file: file_path.to_string(),
+        start_line: node.start_position().row + 1,
+        end_line: node.end_position().row + 1,
+        start_column: node.start_position().column,
+        end_column: node.end_position().column,
+    }
+}
+
+fn first_line(node: Node, source: &[u8]) -> String {
+    node.utf8_text(source)
+        .ok()
+        .and_then(|s| s.lines().next())
+        .unwrap_or("")
+        .trim()
+        .to_string()
+}
+
+fn relation(
+    from: &str,
+    to: &str,
+    relation_type: RelationType,
+    node: Node,
+    file_path: &Path,
+) -> Relation {
+    Relation {
+        from: from.to_string(),
+        to: to.to_string(),
+        relation_type,
+        location: SourceLocation {
+            file: file_path.to_string_lossy().to_string(),
+            start_line: node.start_position().row + 1,
+            end_line: node.end_position().row + 1,
+            start_column: node.start_position().column,
+            end_column: node.end_position().column,
+        },
+        metadata: serde_json::json!({}),
+        to_qualified_hint: None,
+        to_type_hint: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_php_plugin_language_id() {
+        let plugin = PhpPlugin::new().unwrap();
+        assert_eq!(plugin.language_id(), "php");
+    }
+
+    #[test]
+    fn test_extract_class_method_namespace_and_construct() {
+        let source = br#"<?php
+namespace App\Service;
+
+class UserService {
+    public function __construct(private UserRepository $repo) {}
+
+    public function findById(int $id): ?User {
+        return $this->repo->find($id);
+    }
+}
+"#;
+        let plugin = PhpPlugin::new().unwrap();
+        let symbols = plugin
+            .extract_symbols(Path::new("UserService.php"), source)
+            .unwrap();
+
+        let class_sym = symbols
+            .iter()
+            .find(|s| s.name == "UserService" && s.symbol_type == SymbolType::Class)
+            .expect("class");
+        assert_eq!(
+            class_sym.qualified_name.as_deref(),
+            Some("App\\Service\\UserService")
+        );
+        assert!(class_sym.fields.iter().any(|f| f.name == "repo"));
+
+        let ctor = symbols
+            .iter()
+            .find(|s| {
+                s.metadata
+                    .get("is_constructor")
+                    .and_then(|v| v.as_bool())
+                    == Some(true)
+            })
+            .expect("constructor");
+        assert_eq!(ctor.name, "__construct");
+        assert_eq!(
+            ctor.qualified_name.as_deref(),
+            Some("App\\Service\\UserService.<init>")
+        );
+
+        let method = symbols
+            .iter()
+            .find(|s| s.name == "findById")
+            .expect("method");
+        assert_eq!(
+            method.qualified_name.as_deref(),
+            Some("App\\Service\\UserService.findById")
+        );
+        let id_param = method
+            .parameters
+            .iter()
+            .find(|p| p.name == "id")
+            .expect("id param");
+        assert_eq!(id_param.param_type.as_deref(), Some("int"));
+    }
+
+    #[test]
+    fn test_extract_relations_calls_and_implements() {
+        let source = br#"<?php
+namespace App;
+
+class User extends BaseUser implements JsonSerializable {
+    public function save(): void {
+        $this->persist();
+        parent::save();
+    }
+}
+"#;
+        let plugin = PhpPlugin::new().unwrap();
+        let path = Path::new("User.php");
+        let symbols = plugin.extract_symbols(path, source).unwrap();
+        let relations = plugin.extract_relations(path, source, &symbols).unwrap();
+
+        assert!(relations
+            .iter()
+            .any(|r| r.relation_type == RelationType::Extends && r.to == "BaseUser"));
+        assert!(relations.iter().any(|r| {
+            r.relation_type == RelationType::Implements && r.to == "JsonSerializable"
+        }));
+        assert!(relations
+            .iter()
+            .any(|r| r.relation_type == RelationType::Calls));
+    }
+
+    #[test]
+    fn test_calculate_complexity() {
+        let source = br#"<?php
+function check($x) {
+    if ($x > 0) {
+        foreach ($items as $item) {
+            if ($item > 10) return true;
+        }
+    }
+    return false;
+}
+"#;
+        let plugin = PhpPlugin::new().unwrap();
+        let symbols = plugin
+            .extract_symbols(Path::new("check.php"), source)
+            .unwrap();
+        let func = symbols
+            .iter()
+            .find(|s| s.name == "check")
+            .expect("check function");
+        let metrics = plugin.calculate_complexity(func, source).unwrap().unwrap();
+        assert!(metrics.cyclomatic > 1);
+    }
+}

--- a/crates/rgctl-lang-php/src/plugin.rs
+++ b/crates/rgctl-lang-php/src/plugin.rs
@@ -1,7 +1,8 @@
 //! PHP language plugin using Tree-sitter.
 
-use rgctl_plugin_api::{PHP_CALL_KINDS, *};
+use rgctl_plugin_api::{callee_name, containing_function, PHP_CALL_KINDS, *};
 use rgctl_plugin_helpers::ComplexityCalculator;
+use std::collections::HashMap;
 use std::path::Path;
 use tree_sitter::{Node, Parser};
 
@@ -28,12 +29,20 @@ pub struct PhpPlugin {
     _parser: Parser,
 }
 
+fn php_grammar() -> tree_sitter::Language {
+    if std::env::var("RGCTL_PHP_ONLY").is_ok() {
+        tree_sitter_php::LANGUAGE_PHP_ONLY.into()
+    } else {
+        tree_sitter_php::LANGUAGE_PHP.into()
+    }
+}
+
 impl PhpPlugin {
     /// Create a new PHP plugin.
     pub fn new() -> Result<Self> {
         let mut parser = Parser::new();
         parser
-            .set_language(&tree_sitter_php::LANGUAGE_PHP.into())
+            .set_language(&php_grammar())
             .map_err(|e| Error::PluginError(format!("Failed to set PHP grammar: {e}")))?;
         Ok(Self { _parser: parser })
     }
@@ -41,7 +50,7 @@ impl PhpPlugin {
     fn parse(&self, file_path: &Path, source: &[u8]) -> Result<tree_sitter::Tree> {
         let mut parser = Parser::new();
         parser
-            .set_language(&tree_sitter_php::LANGUAGE_PHP.into())
+            .set_language(&php_grammar())
             .map_err(|e| Error::PluginError(format!("Failed to set PHP grammar: {e}")))?;
         parser.parse(source, None).ok_or_else(|| Error::ParseError {
             file: file_path.to_path_buf(),
@@ -93,6 +102,7 @@ impl PhpPlugin {
                 {
                     symbols.push(sym);
                 }
+                self.extract_embedded_symbols(node, source, file_path, namespace.as_deref(), symbols)?;
             }
             "method_declaration" => {
                 if self.find_enclosing_class_name(node, source).is_none() {
@@ -101,6 +111,7 @@ impl PhpPlugin {
                     {
                         symbols.push(sym);
                     }
+                    self.extract_embedded_symbols(node, source, file_path, namespace.as_deref(), symbols)?;
                 }
             }
             "arrow_function" | "anonymous_function" => {
@@ -122,6 +133,9 @@ impl PhpPlugin {
             }
             "enum_declaration" => {
                 symbols.push(self.extract_enum(node, source, file_path, namespace.as_deref())?);
+            }
+            "namespace_use_declaration" => {
+                self.extract_namespace_imports(node, source, file_path, symbols)?;
             }
             _ => {
                 let mut cursor = node.walk();
@@ -162,6 +176,7 @@ impl PhpPlugin {
                 )? {
                     symbols.push(sym);
                 }
+                self.extract_embedded_symbols(child, source, file_path, namespace, symbols)?;
             }
         }
         Ok(())
@@ -185,6 +200,7 @@ impl PhpPlugin {
             .and_then(|n| n.utf8_text(source).ok())
             .map(str::to_string);
         let qualified_name = qualify(namespace, &name);
+        let metadata = php_metadata(node, source);
         Ok(Some(Symbol {
             name,
             symbol_type: SymbolType::Function,
@@ -196,7 +212,7 @@ impl PhpPlugin {
             fields: vec![],
             modifiers: visibility_modifiers(node, source),
             documentation: None,
-            metadata: serde_json::json!({ "language": "php" }),
+            metadata,
         }))
     }
 
@@ -236,7 +252,7 @@ impl PhpPlugin {
                 .or_else(|| Some(qualify(namespace, &name)))
         };
 
-        let mut metadata = serde_json::json!({ "language": "php" });
+        let mut metadata = php_metadata(node, source);
         if is_constructor {
             metadata["is_constructor"] = serde_json::json!(true);
         }
@@ -313,7 +329,7 @@ impl PhpPlugin {
             fields,
             modifiers: visibility_modifiers(node, source),
             documentation: None,
-            metadata: serde_json::json!({ "language": "php" }),
+            metadata: php_metadata(node, source),
         })
     }
 
@@ -427,9 +443,38 @@ impl PhpPlugin {
                     }
                     if let Some(name_node) = elem.child_by_field_name("name") {
                         if let Some(name) = variable_text(name_node, source) {
+                            let mut visibility = vis.clone();
+                            if find_child_kind(elem, "property_hook_list").is_some() {
+                                visibility = visibility.map(|v| format!("{v} hooks"));
+                            }
                             fields.push(Field {
                                 name,
                                 field_type: field_type.clone(),
+                                visibility,
+                            });
+                        }
+                    }
+                }
+            } else if child.kind() == "const_declaration" {
+                let visibility = visibility_modifiers(child, source).join(" ");
+                let vis = if visibility.is_empty() {
+                    Some("const".to_string())
+                } else {
+                    Some(format!("{visibility} const"))
+                };
+                let mut elem_cursor = child.walk();
+                for elem in child.children(&mut elem_cursor) {
+                    if elem.kind() != "const_element" {
+                        continue;
+                    }
+                    if let Some(name_node) = elem
+                        .children(&mut elem.walk())
+                        .find(|c| c.kind() == "name")
+                    {
+                        if let Ok(name) = name_node.utf8_text(source) {
+                            fields.push(Field {
+                                name: name.to_string(),
+                                field_type: None,
                                 visibility: vis.clone(),
                             });
                         }
@@ -546,16 +591,16 @@ impl PhpPlugin {
         symbols: &[Symbol],
     ) -> Result<Vec<Relation>> {
         let mut relations = Vec::new();
-        walk_calls(
+        let import_map = import_map_from_symbols(symbols);
+        walk_php_calls(
             root,
             source,
             file_path,
             symbols,
-            PHP_CALL_KINDS,
-            "php",
+            &import_map,
             &mut relations,
         );
-        self.extract_inheritance(root, source, file_path, &mut relations)?;
+        self.extract_inheritance(root, source, file_path, None, &mut relations)?;
         Ok(relations)
     }
 
@@ -564,6 +609,7 @@ impl PhpPlugin {
         node: Node,
         source: &[u8],
         file_path: &Path,
+        namespace: Option<&str>,
         relations: &mut Vec<Relation>,
     ) -> Result<()> {
         if node.kind() == "class_declaration" {
@@ -597,13 +643,83 @@ impl PhpPlugin {
                         _ => {}
                     }
                 }
+                if let Some(body) = node
+                    .child_by_field_name("body")
+                    .or_else(|| find_child_kind(node, "declaration_list"))
+                {
+                    let mut body_cursor = body.walk();
+                    for child in body.children(&mut body_cursor) {
+                        if child.kind() == "use_declaration" {
+                            for trait_name in trait_names_from_use(child, source) {
+                                let resolved = qualify(namespace, &trait_name);
+                                relations.push(relation(
+                                    &name,
+                                    &resolved,
+                                    RelationType::Uses,
+                                    child,
+                                    file_path,
+                                ));
+                            }
+                        }
+                    }
+                }
             }
         }
 
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
-            self.extract_inheritance(child, source, file_path, relations)?;
+            let child_ns = if child.kind() == "namespace_definition" {
+                child
+                    .child_by_field_name("name")
+                    .and_then(|n| normalize_namespace(n, source))
+                    .or_else(|| namespace.map(str::to_string))
+            } else {
+                namespace.map(str::to_string)
+            };
+            self.extract_inheritance(child, source, file_path, child_ns.as_deref(), relations)?;
         }
+        Ok(())
+    }
+
+    fn extract_namespace_imports(
+        &self,
+        node: Node,
+        source: &[u8],
+        file_path: &str,
+        symbols: &mut Vec<Symbol>,
+    ) -> Result<()> {
+        let prefix = find_child_kind(node, "namespace_name")
+            .and_then(|n| normalize_namespace(n, source));
+        if let Some(body) = node.child_by_field_name("body") {
+            if body.kind() == "namespace_use_group" {
+                let mut cursor = body.walk();
+                for child in body.children(&mut cursor) {
+                    if child.kind() == "namespace_use_clause" {
+                        push_import_symbol(child, source, file_path, prefix.as_deref(), symbols);
+                    }
+                }
+                return Ok(());
+            }
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.kind() == "namespace_use_clause" {
+                push_import_symbol(child, source, file_path, None, symbols);
+            }
+        }
+        Ok(())
+    }
+
+    fn extract_embedded_symbols(
+        &self,
+        node: Node,
+        source: &[u8],
+        file_path: &str,
+        namespace: Option<&str>,
+        symbols: &mut Vec<Symbol>,
+    ) -> Result<()> {
+        let owner = enclosing_owner_name(node, symbols);
+        walk_anonymous_classes(self, node, source, file_path, namespace, owner.as_deref(), symbols);
         Ok(())
     }
 }
@@ -624,7 +740,7 @@ impl LanguagePlugin for PhpPlugin {
     }
 
     fn grammar(&self) -> Option<tree_sitter::Language> {
-        Some(tree_sitter_php::LANGUAGE_PHP.into())
+        Some(php_grammar())
     }
 
     fn extract_symbols(&self, file_path: &Path, source: &[u8]) -> Result<Vec<Symbol>> {
@@ -807,6 +923,408 @@ fn relation(
     }
 }
 
+fn php_metadata(node: Node, source: &[u8]) -> serde_json::Value {
+    let mut meta = serde_json::json!({ "language": "php" });
+    let attrs = collect_attributes(node, source);
+    if !attrs.is_empty() {
+        meta["attributes"] = serde_json::json!(attrs);
+    }
+    meta
+}
+
+fn collect_attributes(node: Node, source: &[u8]) -> Vec<String> {
+    let mut attrs = Vec::new();
+    if let Some(list) = node.child_by_field_name("attributes") {
+        collect_attributes_from_list(list, source, &mut attrs);
+    }
+    attrs
+}
+
+fn collect_attributes_from_list(list: Node, source: &[u8], attrs: &mut Vec<String>) {
+    let mut cursor = list.walk();
+    for child in list.children(&mut cursor) {
+        match child.kind() {
+            "attribute_group" => {
+                let mut gc = child.walk();
+                for attr in child.children(&mut gc) {
+                    if attr.kind() == "attribute" {
+                        push_attribute_text(attr, source, attrs);
+                    }
+                }
+            }
+            "attribute" => push_attribute_text(child, source, attrs),
+            _ => {}
+        }
+    }
+}
+
+fn push_attribute_text(attr: Node, source: &[u8], attrs: &mut Vec<String>) {
+    let name = attr
+        .child_by_field_name("name")
+        .or_else(|| {
+            attr.children(&mut attr.walk())
+                .find(|c| matches!(c.kind(), "name" | "qualified_name" | "relative_name"))
+        })
+        .and_then(|n| n.utf8_text(source).ok())
+        .map(|s| s.trim_start_matches('\\').to_string());
+    if let Some(name) = name {
+        if let Some(params) = attr.child_by_field_name("parameters") {
+            if let Ok(args) = params.utf8_text(source) {
+                attrs.push(format!("{name}{args}"));
+                return;
+            }
+        }
+        attrs.push(name);
+    }
+}
+
+fn import_map_from_symbols(symbols: &[Symbol]) -> HashMap<String, String> {
+    symbols
+        .iter()
+        .filter(|s| s.symbol_type == SymbolType::Import)
+        .filter_map(|s| {
+            let qn = s.qualified_name.as_ref()?;
+            Some((s.name.clone(), qn.clone()))
+        })
+        .collect()
+}
+
+fn push_import_symbol(
+    clause: Node,
+    source: &[u8],
+    file_path: &str,
+    prefix: Option<&str>,
+    symbols: &mut Vec<Symbol>,
+) {
+    let Some((local, qualified)) = clause_import_names(clause, source, prefix) else {
+        return;
+    };
+    symbols.push(Symbol {
+        name: local,
+        symbol_type: SymbolType::Import,
+        qualified_name: Some(qualified),
+        location: source_location(clause, file_path),
+        signature: Some(first_line(clause, source)),
+        return_type: None,
+        parameters: vec![],
+        fields: vec![],
+        modifiers: vec![],
+        documentation: None,
+        metadata: serde_json::json!({ "language": "php", "kind": "import" }),
+    });
+}
+
+fn clause_import_names(
+    clause: Node,
+    source: &[u8],
+    prefix: Option<&str>,
+) -> Option<(String, String)> {
+    let alias = clause
+        .child_by_field_name("alias")
+        .and_then(|n| n.utf8_text(source).ok())
+        .map(str::to_string);
+    let base = clause
+        .children(&mut clause.walk())
+        .find(|c| matches!(c.kind(), "name" | "qualified_name" | "relative_name"))
+        .and_then(|n| n.utf8_text(source).ok())
+        .map(|s| s.trim_start_matches('\\').to_string())?;
+    let qualified = match prefix {
+        Some(p) if !base.contains('\\') => format!("{p}\\{base}"),
+        _ => base.clone(),
+    };
+    let local = alias.unwrap_or_else(|| {
+        qualified
+            .rsplit('\\')
+            .next()
+            .unwrap_or(&qualified)
+            .to_string()
+    });
+    Some((local, qualified))
+}
+
+fn trait_names_from_use(node: Node, source: &[u8]) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "name" | "qualified_name" | "relative_name" => {
+                if let Ok(text) = child.utf8_text(source) {
+                    names.push(text.trim_start_matches('\\').to_string());
+                }
+            }
+            "use_list" => {
+                let mut lc = child.walk();
+                for item in child.children(&mut lc) {
+                    if item.kind() == "use_as_clause" {
+                        if let Some(n) = item
+                            .children(&mut item.walk())
+                            .find(|c| matches!(c.kind(), "name" | "qualified_name"))
+                        {
+                            if let Ok(text) = n.utf8_text(source) {
+                                names.push(text.trim_start_matches('\\').to_string());
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    names
+}
+
+fn enclosing_owner_name(node: Node, symbols: &[Symbol]) -> Option<String> {
+    let line = node.start_position().row + 1;
+    symbols
+        .iter()
+        .filter(|s| s.symbol_type == SymbolType::Function)
+        .filter(|s| line >= s.location.start_line && line <= s.location.end_line)
+        .min_by_key(|s| s.location.end_line - s.location.start_line)
+        .and_then(|s| s.qualified_name.clone())
+}
+
+fn walk_anonymous_classes(
+    plugin: &PhpPlugin,
+    root: Node,
+    source: &[u8],
+    file_path: &str,
+    namespace: Option<&str>,
+    owner: Option<&str>,
+    symbols: &mut Vec<Symbol>,
+) {
+    const MAX_DEPTH: usize = 2048;
+    let mut stack = vec![(root, 0usize)];
+    while let Some((node, depth)) = stack.pop() {
+        if depth > MAX_DEPTH {
+            continue;
+        }
+        if node.kind() == "anonymous_class" {
+            let line = node.start_position().row + 1;
+            let anon_name = format!("$Anonymous{line}");
+            let qualified = owner
+                .map(|o| format!("{o}.{anon_name}"))
+                .unwrap_or_else(|| qualify(namespace, &anon_name));
+            symbols.push(Symbol {
+                name: anon_name.clone(),
+                symbol_type: SymbolType::Class,
+                qualified_name: Some(qualified.clone()),
+                location: source_location(node, file_path),
+                signature: None,
+                return_type: None,
+                parameters: vec![],
+                fields: vec![],
+                modifiers: vec![],
+                documentation: None,
+                metadata: serde_json::json!({
+                    "language": "php",
+                    "is_anonymous": true,
+                    "owner": owner,
+                }),
+            });
+            if let Some(body) = node
+                .child_by_field_name("body")
+                .or_else(|| find_child_kind(node, "declaration_list"))
+            {
+                let mut cursor = body.walk();
+                for child in body.children(&mut cursor) {
+                    if child.kind() == "method_declaration" {
+                        if let Ok(Some(method)) = plugin.extract_method(
+                            child,
+                            source,
+                            file_path,
+                            namespace,
+                            Some(qualified.as_str()),
+                        ) {
+                            symbols.push(method);
+                        }
+                    }
+                }
+            }
+        }
+        for i in (0..node.child_count()).rev() {
+            if let Some(child) = node.child(i) {
+                stack.push((child, depth + 1));
+            }
+        }
+    }
+}
+
+fn walk_php_calls(
+    root: Node,
+    source: &[u8],
+    file_path: &Path,
+    symbols: &[Symbol],
+    import_map: &HashMap<String, String>,
+    relations: &mut Vec<Relation>,
+) {
+    const MAX_DEPTH: usize = 2048;
+    let function_symbols: Vec<&Symbol> = symbols
+        .iter()
+        .filter(|s| s.symbol_type == SymbolType::Function)
+        .collect();
+    let mut stack = vec![(root, 0usize)];
+    while let Some((node, depth)) = stack.pop() {
+        if depth > MAX_DEPTH {
+            continue;
+        }
+        if PHP_CALL_KINDS.contains(&node.kind()) {
+            push_php_call_relation(
+                node,
+                source,
+                file_path,
+                symbols,
+                &function_symbols,
+                import_map,
+                relations,
+            );
+        }
+        for i in (0..node.child_count()).rev() {
+            if let Some(child) = node.child(i) {
+                stack.push((child, depth + 1));
+            }
+        }
+    }
+}
+
+fn push_php_call_relation(
+    node: Node,
+    source: &[u8],
+    file_path: &Path,
+    symbols: &[Symbol],
+    function_symbols: &[&Symbol],
+    import_map: &HashMap<String, String>,
+    relations: &mut Vec<Relation>,
+) {
+    let Some((callee, unresolved, scope_class)) = php_call_target(node, source) else {
+        return;
+    };
+    if callee.is_empty() {
+        return;
+    }
+    let Some(from_fn) = containing_function(node, function_symbols) else {
+        return;
+    };
+    let from = from_fn
+        .qualified_name
+        .clone()
+        .unwrap_or_else(|| from_fn.name.clone());
+
+    let to_qualified_hint = scope_class.as_ref().and_then(|cls| {
+        import_map
+            .get(cls)
+            .map(|fqn| format!("{fqn}.{callee}"))
+    });
+
+    let mut meta = serde_json::json!({ "language": "php" });
+    if unresolved {
+        meta["unresolved"] = serde_json::json!(true);
+    }
+
+    let same_file_matches: Vec<_> = symbols
+        .iter()
+        .filter(|s| {
+            s.name == callee
+                && s.symbol_type == SymbolType::Function
+                && s.location.file == file_path.to_string_lossy()
+        })
+        .collect();
+    let local_target = match same_file_matches.as_slice() {
+        [only] => only
+            .qualified_name
+            .clone()
+            .unwrap_or_else(|| callee.clone()),
+        _ => to_qualified_hint.clone().unwrap_or_else(|| callee.clone()),
+    };
+
+    relations.push(Relation {
+        from,
+        to: local_target,
+        relation_type: RelationType::Calls,
+        location: SourceLocation {
+            file: file_path.to_string_lossy().to_string(),
+            start_line: node.start_position().row + 1,
+            end_line: node.end_position().row + 1,
+            start_column: node.start_position().column,
+            end_column: node.end_position().column,
+        },
+        metadata: meta,
+        to_qualified_hint,
+        to_type_hint: None,
+    });
+}
+
+fn php_call_target(node: Node, source: &[u8]) -> Option<(String, bool, Option<String>)> {
+    match node.kind() {
+        "scoped_call_expression" => {
+            let scope = node.child_by_field_name("scope")?;
+            let name_node = node.child_by_field_name("name")?;
+            let class = type_text(scope, source)?;
+            let (method, unresolved) = method_name_from_node(name_node, source);
+            Some((method, unresolved, Some(class)))
+        }
+        "member_call_expression" | "nullsafe_member_call_expression" => {
+            let name_node = node.child_by_field_name("name")?;
+            let (method, unresolved) = method_name_from_node(name_node, source);
+            let target = if unresolved {
+                format!("${method}")
+            } else {
+                method
+            };
+            Some((target, unresolved, None))
+        }
+        "function_call_expression" => {
+            let func = node.child_by_field_name("function")?;
+            if matches!(
+                func.kind(),
+                "variable_name" | "dynamic_variable_name" | "expression"
+            ) {
+                let name = func
+                    .utf8_text(source)
+                    .ok()
+                    .map(|s| s.trim_start_matches('$').to_string())
+                    .unwrap_or_else(|| "dynamic".to_string());
+                return Some((name, true, None));
+            }
+            callee_name(node, source).map(|c| (c, false, None))
+        }
+        _ => callee_name(node, source).map(|c| (c, false, None)),
+    }
+}
+
+fn method_name_from_node(name_node: Node, source: &[u8]) -> (String, bool) {
+    match name_node.kind() {
+        "name" => (
+            name_node
+                .utf8_text(source)
+                .unwrap_or("")
+                .to_string(),
+            false,
+        ),
+        "variable_name" | "dynamic_variable_name" => (
+            name_node
+                .utf8_text(source)
+                .unwrap_or("")
+                .trim_start_matches('$')
+                .to_string(),
+            true,
+        ),
+        _ => (
+            callee_name(name_node, source).unwrap_or_else(|| "$dynamic".to_string()),
+            true,
+        ),
+    }
+}
+
+fn type_text(node: Node, source: &[u8]) -> Option<String> {
+    if let Ok(text) = node.utf8_text(source) {
+        return Some(text.trim_start_matches('\\').to_string());
+    }
+    node.child_by_field_name("name")
+        .and_then(|n| n.utf8_text(source).ok())
+        .map(|s| s.trim_start_matches('\\').to_string())
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -902,6 +1420,153 @@ class User extends BaseUser implements JsonSerializable {
         assert!(relations
             .iter()
             .any(|r| r.relation_type == RelationType::Calls));
+    }
+
+    #[test]
+    fn test_trait_use_relations() {
+        let source = br#"<?php
+namespace App;
+class C {
+    use A, B;
+}
+"#;
+        let plugin = PhpPlugin::new().unwrap();
+        let path = Path::new("C.php");
+        let symbols = plugin.extract_symbols(path, source).unwrap();
+        let relations = plugin.extract_relations(path, source, &symbols).unwrap();
+        assert!(relations.iter().any(|r| {
+            r.relation_type == RelationType::Uses && r.to == "A"
+        }));
+        assert!(relations.iter().any(|r| {
+            r.relation_type == RelationType::Uses && r.to == "B"
+        }));
+    }
+
+    #[test]
+    fn test_namespace_import_symbols() {
+        let source = br#"<?php
+namespace App;
+use App\Service\AuthService;
+use App\Model\OrderDTO as Order;
+use Foo\{Bar, Baz as Q};
+"#;
+        let plugin = PhpPlugin::new().unwrap();
+        let symbols = plugin
+            .extract_symbols(Path::new("imports.php"), source)
+            .unwrap();
+        let imports: Vec<_> = symbols
+            .iter()
+            .filter(|s| s.symbol_type == SymbolType::Import)
+            .collect();
+        assert_eq!(imports.len(), 4);
+        assert!(imports.iter().any(|s| {
+            s.name == "AuthService" && s.qualified_name.as_deref() == Some("App\\Service\\AuthService")
+        }));
+        assert!(imports.iter().any(|s| s.name == "Order"));
+        assert!(imports.iter().any(|s| s.name == "Bar"));
+        assert!(imports.iter().any(|s| s.name == "Q"));
+    }
+
+    #[test]
+    fn test_import_aware_static_call_hint() {
+        let source = br#"<?php
+namespace App;
+use App\Service\AuthService;
+function run() {
+    AuthService::login('x');
+}
+"#;
+        let plugin = PhpPlugin::new().unwrap();
+        let path = Path::new("run.php");
+        let symbols = plugin.extract_symbols(path, source).unwrap();
+        let relations = plugin.extract_relations(path, source, &symbols).unwrap();
+        let call = relations
+            .iter()
+            .find(|r| r.relation_type == RelationType::Calls)
+            .expect("call");
+        assert_eq!(
+            call.to_qualified_hint.as_deref(),
+            Some("App\\Service\\AuthService.login")
+        );
+    }
+
+    #[test]
+    fn test_anonymous_class_and_attributes() {
+        let source = br#"<?php
+namespace App;
+#[Route('/api')]
+class C {
+    public function factory() {
+        return new class {
+            public function m(): void {}
+        };
+    }
+}
+"#;
+        let plugin = PhpPlugin::new().unwrap();
+        let path = Path::new("Anon.php");
+        let symbols = plugin.extract_symbols(path, source).unwrap();
+        let class = symbols
+            .iter()
+            .find(|s| s.name == "C")
+            .expect("class");
+        assert!(class
+            .metadata
+            .get("attributes")
+            .and_then(|v| v.as_array())
+            .is_some_and(|a| a.iter().any(|v| v.as_str().is_some_and(|s| s.contains("Route")))));
+        assert!(symbols.iter().any(|s| s.name.starts_with("$Anonymous")));
+        assert!(symbols.iter().any(|s| s.name == "m"));
+    }
+
+    #[test]
+    fn test_dynamic_call_unresolved() {
+        let source = br#"<?php
+function dyn($obj, $method) {
+    $obj->$method();
+}
+"#;
+        let plugin = PhpPlugin::new().unwrap();
+        let path = Path::new("dyn.php");
+        let symbols = plugin.extract_symbols(path, source).unwrap();
+        let relations = plugin.extract_relations(path, source, &symbols).unwrap();
+        let call = relations
+            .iter()
+            .find(|r| r.relation_type == RelationType::Calls)
+            .expect("call");
+        assert_eq!(call.metadata.get("unresolved").and_then(|v| v.as_bool()), Some(true));
+    }
+
+    #[test]
+    fn test_class_const_field() {
+        let source = br#"<?php
+class C {
+    public const VERSION = '1.0';
+}
+"#;
+        let plugin = PhpPlugin::new().unwrap();
+        let symbols = plugin
+            .extract_symbols(Path::new("C.php"), source)
+            .unwrap();
+        let class = symbols.iter().find(|s| s.name == "C").expect("class");
+        assert!(class.fields.iter().any(|f| f.name == "VERSION"));
+    }
+
+    #[test]
+    fn test_first_class_callable_strlen() {
+        let source = br#"<?php
+function f() {
+    $g = strlen(...);
+    $g('x');
+}
+"#;
+        let plugin = PhpPlugin::new().unwrap();
+        let path = Path::new("fcc.php");
+        let symbols = plugin.extract_symbols(path, source).unwrap();
+        let relations = plugin.extract_relations(path, source, &symbols).unwrap();
+        assert!(relations.iter().any(|r| {
+            r.relation_type == RelationType::Calls && r.to == "strlen"
+        }));
     }
 
     #[test]

--- a/crates/rgctl-lang-python/Cargo.toml
+++ b/crates/rgctl-lang-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-lang-python"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "rgctl language plugin: python"

--- a/crates/rgctl-lang-runtime/Cargo.toml
+++ b/crates/rgctl-lang-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-lang-runtime"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Generic tree-sitter and regex language plugins for rgctl"

--- a/crates/rgctl-lang-rust/Cargo.toml
+++ b/crates/rgctl-lang-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-lang-rust"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "rgctl language plugin: rust"

--- a/crates/rgctl-lang-typescript/Cargo.toml
+++ b/crates/rgctl-lang-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-lang-typescript"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "rgctl language plugin: typescript"

--- a/crates/rgctl-languages/Cargo.toml
+++ b/crates/rgctl-languages/Cargo.toml
@@ -19,3 +19,4 @@ rgctl-lang-csharp = { workspace = true }
 rgctl-lang-c = { workspace = true }
 rgctl-lang-cpp = { workspace = true }
 rgctl-lang-markdown = { workspace = true }
+rgctl-lang-php = { workspace = true }

--- a/crates/rgctl-languages/Cargo.toml
+++ b/crates/rgctl-languages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-languages"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Built-in Tier 1 language plugins for rgctl"

--- a/crates/rgctl-languages/src/lib.rs
+++ b/crates/rgctl-languages/src/lib.rs
@@ -14,6 +14,7 @@ pub fn register_languages(registry: &mut LanguageRegistry) {
     rgctl_lang_c::register(registry);
     rgctl_lang_cpp::register(registry);
     rgctl_lang_markdown::register(registry);
+    rgctl_lang_php::register(registry);
 }
 
 /// Default registry with config formats and all built-in languages.
@@ -49,6 +50,16 @@ mod tests {
         assert!(registry.can_process_file(Path::new("notes/page.mdx")));
         let langs = registry.supported_languages();
         assert!(langs.iter().any(|l| l == "markdown"));
+    }
+
+    #[test]
+    fn default_registry_can_process_php_files() {
+        let registry = default_registry();
+        assert!(registry.can_process_file(Path::new("app/Service.php")));
+        let plugin = registry
+            .get_plugin_for_file(Path::new("src/User.php"))
+            .expect("php plugin");
+        assert_eq!(plugin.language_id(), "php");
     }
 
     #[test]

--- a/crates/rgctl-pipeline/Cargo.toml
+++ b/crates/rgctl-pipeline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-pipeline"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Parallel processing pipeline for rgctl"

--- a/crates/rgctl-plugin-api/Cargo.toml
+++ b/crates/rgctl-plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-plugin-api"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Stable plugin API for rgctl language and config format plugins"

--- a/crates/rgctl-plugin-api/src/call_extraction.rs
+++ b/crates/rgctl-plugin-api/src/call_extraction.rs
@@ -13,6 +13,12 @@ pub const C_CALL_KINDS: &[&str] = &["call_expression"];
 pub const CPP_CALL_KINDS: &[&str] = &["call_expression"];
 pub const JS_CALL_KINDS: &[&str] = &["call_expression"];
 pub const TS_CALL_KINDS: &[&str] = &["call_expression"];
+pub const PHP_CALL_KINDS: &[&str] = &[
+    "function_call_expression",
+    "member_call_expression",
+    "scoped_call_expression",
+    "nullsafe_member_call_expression",
+];
 
 /// Find the innermost function symbol containing `node`.
 ///
@@ -38,8 +44,12 @@ pub fn callee_name(root: Node, source: &[u8]) -> Option<String> {
 
         match node.kind() {
             // Go method/field selectors use `field_identifier` (not `identifier`).
-            "identifier" | "type_identifier" | "field_identifier" | "property_identifier" => {
-                return node.utf8_text(source).ok().map(str::to_string);
+            // PHP method names use the `name` node kind.
+            "identifier" | "type_identifier" | "field_identifier" | "property_identifier"
+            | "name" | "variable_name" => {
+                return node.utf8_text(source).ok().map(|s| {
+                    s.trim_start_matches('$').to_string()
+                });
             }
             "field_expression" | "selector_expression" | "attribute" | "member_expression" => {
                 if let Some(n) = node

--- a/crates/rgctl-plugin-api/src/lib.rs
+++ b/crates/rgctl-plugin-api/src/lib.rs
@@ -9,8 +9,8 @@ mod registrar;
 
 pub use call_extraction::{
     C_CALL_KINDS, CPP_CALL_KINDS, CSHARP_CALL_KINDS, GO_CALL_KINDS, JS_CALL_KINDS,
-    PYTHON_CALL_KINDS, RUST_CALL_KINDS, TS_CALL_KINDS, callee_name, containing_function,
-    push_call_relation, walk_calls,
+    PHP_CALL_KINDS, PYTHON_CALL_KINDS, RUST_CALL_KINDS, TS_CALL_KINDS, callee_name,
+    containing_function, push_call_relation, walk_calls,
 };
 
 pub use error::{Error, Result};

--- a/crates/rgctl-plugin-helpers/Cargo.toml
+++ b/crates/rgctl-plugin-helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-plugin-helpers"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Tree-sitter extraction helpers for rgctl plugins"

--- a/crates/rgctl-project-config/Cargo.toml
+++ b/crates/rgctl-project-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-project-config"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Project configuration analysis for rgctl"

--- a/crates/rgctl-registry/Cargo.toml
+++ b/crates/rgctl-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-registry"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Language plugin registry for rgctl"

--- a/crates/rgctl-rules/Cargo.toml
+++ b/crates/rgctl-rules/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-rules"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Rule engine for rgctl"

--- a/crates/rgctl-security/Cargo.toml
+++ b/crates/rgctl-security/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-security"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Security analysis for rgctl"

--- a/crates/rgctl-semantic/Cargo.toml
+++ b/crates/rgctl-semantic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-semantic"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Semantic analysis and IDL generation for rgctl"

--- a/crates/rgctl-service/Cargo.toml
+++ b/crates/rgctl-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-service"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Shared command execution for rgctl CLI, HTTP, and MCP"

--- a/crates/rgctl-wasm/Cargo.toml
+++ b/crates/rgctl-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-wasm"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "WASM graph engine for rgctl dashboard"

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -25,6 +25,7 @@ rgctl indexes source through **language plugins**. Tier metadata: [`languages.to
 | C# | `.cs` | |
 | C | `.c`, `.h` | |
 | C++ | `.cpp`, `.cc`, `.cxx`, `.hpp`, … | |
+| PHP | `.php` | |
 
 ```bash
 rgctl discover . -l java,go,rust

--- a/docs/tier-1-language-support.md
+++ b/docs/tier-1-language-support.md
@@ -18,7 +18,7 @@ rgctl uses a **hybrid tiering** model:
 | **Tier 2** | Generic tree-sitter | `rgctl-lang-{id}/` + `config.rs` | Kinds from `LanguageConfig` | Optional | Usually none | Not required |
 | **Tier 3** | Regex | `rgctl-lang-{id}/` + regex patterns | Pattern-based symbols | No | No | No |
 
-**Tier 1 custom plugins today:** Rust, Python, TypeScript, JavaScript, Go, Java, C#, C, C++ — see `languages.toml` (`handler = "custom"`).
+**Tier 1 custom plugins today:** Rust, Python, TypeScript, JavaScript, Go, Java, C#, C, C++, PHP — see `languages.toml` (`handler = "custom"`).
 
 **Markdown** is a separate **custom markup plugin** (`rgctl-lang-markdown`): documentation context graph only — not Tier 1 and not generic Tier 2. See [markdown-context.md](markdown-context.md).
 
@@ -414,6 +414,7 @@ Copy into your PR description:
 | Python | 1 custom | ✅ | ✅ | ✅ richest | `dashboard_ecommerce_python` | ✅ F1–F6 |
 | Rust | 1 custom | ✅ | ✅ | ✅ rich | `dashboard_ecommerce_rust` | ✅ F1–F6 |
 | JS / TS | 1 custom | ✅ | ✅ | ✅ rich | `dashboard_ecommerce_javascript`, `dashboard_ecommerce_typescript` | ✅ F1–F6 (JS weaker types) |
+| PHP | 1 custom | ✅ | ✅ | ✅ | `dashboard_ecommerce_php` | ✅ F1–F6 |
 
 Layer F golden coverage lives in `crates/rgctl-analysis/src/field_write.rs` (`*_cfg_captures_field_write_and_query`). Update this table when promoting a language or when F tests regress.
 

--- a/docs/tier-1-language-support.md
+++ b/docs/tier-1-language-support.md
@@ -414,7 +414,7 @@ Copy into your PR description:
 | Python | 1 custom | ✅ | ✅ | ✅ richest | `dashboard_ecommerce_python` | ✅ F1–F6 |
 | Rust | 1 custom | ✅ | ✅ | ✅ rich | `dashboard_ecommerce_rust` | ✅ F1–F6 |
 | JS / TS | 1 custom | ✅ | ✅ | ✅ rich | `dashboard_ecommerce_javascript`, `dashboard_ecommerce_typescript` | ✅ F1–F6 (JS weaker types) |
-| PHP | 1 custom | ✅ | ✅ | ✅ | `dashboard_ecommerce_php` | ✅ F1–F6 |
+| PHP | 1 custom | ✅ + Uses (traits), Import, attributes, anonymous classes | ✅ | ✅ + `$_FILES`, `filter_input`, `prepare` | `dashboard_ecommerce_php` | ✅ F1–F6 |
 
 Layer F golden coverage lives in `crates/rgctl-analysis/src/field_write.rs` (`*_cfg_captures_field_write_and_query`). Update this table when promoting a language or when F tests regress.
 

--- a/docs/videos/README.md
+++ b/docs/videos/README.md
@@ -60,3 +60,22 @@ cargo build --release
 Defaults: one beat per main tab (Dataflow shows mutations + PDG + dominator). Hold `DEMO_HOLD_SEC` (default 6.5). Override symbols with `CAPTURE_FN_*` / `CAPTURE_SEMANTIC_QUERY` / `MUTATIONS_TYPE`.
 
 Captions need ffmpeg with `subtitles` (`brew install ffmpeg-full`).
+
+---
+
+## CoolStore microservice decomposition (VHS)
+
+Blog walkthrough for [Decomposing a Monolith into Microservices](https://shaaf.dev/post/decomposing-a-monolith-into-microservices-with-call-graph-analysis/) on `example/coolstore-weblogic`.
+
+| File | Purpose |
+|------|---------|
+| [`microservices-decomposition-cli.tape`](microservices-decomposition-cli.tape) | VHS script |
+| [`record-microservices-decomposition-cli.sh`](record-microservices-decomposition-cli.sh) | Record → `microservices-decomposition-cli-no-captions.{gif,mp4}` |
+| [`microservices-decomposition-cli.srt`](microservices-decomposition-cli.srt) | Subtitle cues |
+| [`burn-microservices-decomposition-cli.sh`](burn-microservices-decomposition-cli.sh) | Burn → `microservices-decomposition-cli.mp4` |
+
+```bash
+cargo build --release
+./docs/videos/record-microservices-decomposition-cli.sh
+./docs/videos/burn-microservices-decomposition-cli.sh
+```

--- a/example/README.md
+++ b/example/README.md
@@ -7,6 +7,8 @@
 | `linux/` | Linux kernel tree (maintainer checkout) | `linux_cold_discover_within_baseline` — default discover, wall ≤ **145 s** (+10%) |
 | `metasfresh-4.9.8b/` | metasfresh ERP checkout | `metasfresh_cold_discover_within_baseline` — `discover --full`, wall ≤ **74 s** (+10%) |
 | `kafka/` | Kafka source tree | `kafka_cold_discover_within_baseline` |
+| `kubernetes/` | Kubernetes source tree | manual / future gate |
+| `magento2/` | [Magento Open Source](https://github.com/magento/magento2) | PHP stress corpus — `discover app lib setup -l php` (exclude `vendor/`, `generated/`) |
 | `k8s-website/` | [kubernetes/website](https://github.com/kubernetes/website) `content/en` | `./scripts/fetch-profile-repos.sh` then `k8s_website_markdown_cold_discover_within_baseline -- --ignored` or `k8s_website_obsidian_export_to_vault -- --ignored` (after discover) |
 
 Manual stage breakdown: [docs/internal/profile.md](../docs/internal/profile.md) (`example/linux` + `example/metasfresh-4.9.8b`; run from inside the corpus dir).
@@ -29,8 +31,9 @@ The fetch script now pulls all large profiling fixtures in one go:
 - `example/metasfresh-4.9.8b`
 - `example/coolstore-weblogic`
 - `example/kubernetes`
+- `example/magento2`
 - `example/k8s-website` (sparse `content/en`)
 
-Override paths with `RGCTL_LINUX_REPO`, `RGCTL_KAFKA_REPO`, or `RGCTL_K8S_WEBSITE_REPO`.
+Override paths with `RGCTL_LINUX_REPO`, `RGCTL_KAFKA_REPO`, `RGCTL_K8S_WEBSITE_REPO`, or `RGCTL_MAGENTO2_REPO`.
 
 **Cold profile:** gates remove `example/<repo>/.rgctl/` before discover and require `target/release/rgctl` (`cargo build --release --bin rgctl`). Do not profile against a warm or partial cache — numbers will be wrong.

--- a/languages.toml
+++ b/languages.toml
@@ -123,3 +123,16 @@ class_kinds = ["struct_specifier", "enum_specifier"]
 import_kinds = ["preprocessor_include"]
 enable_complexity = true
 enable_type_inference = false
+
+[languages.php]
+handler = "custom"
+plugin = "PhpPlugin"
+module = "crate::languages::builtin::php"
+crate = "tree-sitter-php"
+extensions = ["php"]
+aliases = ["php"]
+function_kinds = ["function_definition", "method_declaration", "arrow_function", "anonymous_function"]
+class_kinds = ["class_declaration", "interface_declaration", "trait_declaration", "enum_declaration"]
+import_kinds = ["namespace_use_declaration", "use_declaration"]
+enable_complexity = true
+enable_type_inference = false

--- a/rgctl-macros/Cargo.toml
+++ b/rgctl-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgctl-macros"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 description = "Procedural macros for rgctl language plugins"

--- a/rgctl-tests/ecommerce-php/README.md
+++ b/rgctl-tests/ecommerce-php/README.md
@@ -1,0 +1,9 @@
+# ecommerce-php
+
+PHP reference fixture for rgctl Tier 1 language support.
+
+Small MVC-style app: controller → service → repository, with auth flow, one taint path, and field-write mutation coverage.
+
+```bash
+rgctl discover . --with-cfg --with-taint -l php
+```

--- a/rgctl-tests/ecommerce-php/fixtures/attributes_and_anonymous.php
+++ b/rgctl-tests/ecommerce-php/fixtures/attributes_and_anonymous.php
@@ -1,0 +1,16 @@
+<?php
+namespace App\Fixtures;
+
+#[Route('/api/v1')]
+class ApiController
+{
+    public function factory(): object
+    {
+        return new class {
+            public function handle(): string
+            {
+                return 'ok';
+            }
+        };
+    }
+}

--- a/rgctl-tests/ecommerce-php/fixtures/property_hook.php
+++ b/rgctl-tests/ecommerce-php/fixtures/property_hook.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Fixtures;
+
+class PropertyHookSample
+{
+    public string $label {
+        get => strtoupper($this->label);
+        set => $this->label = $value;
+    }
+}

--- a/rgctl-tests/ecommerce-php/fixtures/traits_and_imports.php
+++ b/rgctl-tests/ecommerce-php/fixtures/traits_and_imports.php
@@ -1,0 +1,23 @@
+<?php
+namespace App\Fixtures;
+
+use App\Traits\Timestampable;
+use App\Service\{AuthService, OrderDTO as Order};
+
+trait Loggable
+{
+    public function log(string $msg): void {}
+}
+
+class SampleService
+{
+    use Timestampable, Loggable;
+
+    public function run(AuthService $auth): void
+    {
+        AuthService::login('x');
+        $obj = null;
+        $method = 'ping';
+        $obj->$method();
+    }
+}

--- a/rgctl-tests/ecommerce-php/src/Controller/AuthController.php
+++ b/rgctl-tests/ecommerce-php/src/Controller/AuthController.php
@@ -1,0 +1,15 @@
+<?php
+namespace App\Controller;
+
+use App\Service\AuthService;
+
+class AuthController
+{
+    public function __construct(private AuthService $authService) {}
+
+    public function login(): ?array
+    {
+        $email = $_POST['email'] ?? '';
+        return $this->authService->login($email);
+    }
+}

--- a/rgctl-tests/ecommerce-php/src/Controller/AuthController.php
+++ b/rgctl-tests/ecommerce-php/src/Controller/AuthController.php
@@ -3,6 +3,7 @@ namespace App\Controller;
 
 use App\Service\AuthService;
 
+#[Route('/auth')]
 class AuthController
 {
     public function __construct(private AuthService $authService) {}
@@ -11,5 +12,15 @@ class AuthController
     {
         $email = $_POST['email'] ?? '';
         return $this->authService->login($email);
+    }
+
+    public function createHandler(): object
+    {
+        return new class {
+            public function handle(): string
+            {
+                return 'ok';
+            }
+        };
     }
 }

--- a/rgctl-tests/ecommerce-php/src/Model/OrderDTO.php
+++ b/rgctl-tests/ecommerce-php/src/Model/OrderDTO.php
@@ -1,0 +1,12 @@
+<?php
+namespace App\Model;
+
+class OrderDTO
+{
+    public function __construct(private string $status) {}
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+}

--- a/rgctl-tests/ecommerce-php/src/Repository/UserRepository.php
+++ b/rgctl-tests/ecommerce-php/src/Repository/UserRepository.php
@@ -1,0 +1,15 @@
+<?php
+namespace App\Repository;
+
+class UserRepository
+{
+    public function findByEmail(string $email): ?array
+    {
+        return ['email' => $email, 'id' => 1];
+    }
+
+    public function persist(array $user): void
+    {
+        // no-op persistence stub
+    }
+}

--- a/rgctl-tests/ecommerce-php/src/Service/AuthService.php
+++ b/rgctl-tests/ecommerce-php/src/Service/AuthService.php
@@ -1,0 +1,32 @@
+<?php
+namespace App\Service;
+
+use App\Repository\UserRepository;
+use App\Model\OrderDTO;
+
+class AuthService
+{
+    public function __construct(private UserRepository $repository) {}
+
+    public function login(string $email): ?array
+    {
+        $user = $this->repository->findByEmail($email);
+        if ($user === null) {
+            return null;
+        }
+        $this->repository->persist($user);
+        return $user;
+    }
+
+    public function unsafeQuery(): void
+    {
+        $id = $_GET['id'];
+        $query = "SELECT * FROM users WHERE id = " . $id;
+        mysqli_query($GLOBALS['conn'], $query);
+    }
+
+    public function processOrder(OrderDTO $order): void
+    {
+        $order->status = 'PROCESSED';
+    }
+}

--- a/rgctl-tests/ecommerce-php/src/Service/AuthService.php
+++ b/rgctl-tests/ecommerce-php/src/Service/AuthService.php
@@ -3,9 +3,14 @@ namespace App\Service;
 
 use App\Repository\UserRepository;
 use App\Model\OrderDTO;
+use App\Traits\Timestampable;
 
 class AuthService
 {
+    use Timestampable;
+
+    public const VERSION = '1.0';
+
     public function __construct(private UserRepository $repository) {}
 
     public function login(string $email): ?array

--- a/rgctl-tests/ecommerce-php/src/Traits/Timestampable.php
+++ b/rgctl-tests/ecommerce-php/src/Traits/Timestampable.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Traits;
+
+trait Timestampable
+{
+    public function touch(): void
+    {
+        $this->updatedAt = time();
+    }
+}

--- a/scripts/fetch-profile-repos.sh
+++ b/scripts/fetch-profile-repos.sh
@@ -6,6 +6,7 @@
 # - metasfresh
 # - coolstore-weblogic
 # - kubernetes
+# - magento2 (Magento Open Source — PHP migration stress corpus)
 # - k8s-website (kubernetes/website content/en via sparse checkout)
 set -euo pipefail
 
@@ -52,6 +53,7 @@ clone_if_missing "https://github.com/apache/kafka.git" "$EXAMPLE_DIR/kafka"
 clone_if_missing "https://github.com/metasfresh/metasfresh.git" "$EXAMPLE_DIR/metasfresh-4.9.8b"
 clone_if_missing "https://github.com/konveyor-ecosystem/coolstore.git" "$EXAMPLE_DIR/coolstore-weblogic"
 clone_if_missing "https://github.com/kubernetes/kubernetes.git" "$EXAMPLE_DIR/kubernetes"
+clone_if_missing "https://github.com/magento/magento2.git" "$EXAMPLE_DIR/magento2"
 
 # Sparse docs corpus
 clone_sparse_k8s_website_if_missing "$EXAMPLE_DIR/k8s-website"

--- a/tests/dashboard_ecommerce_php.rs
+++ b/tests/dashboard_ecommerce_php.rs
@@ -55,7 +55,7 @@ fn discover_all_writes_php_cfg_dashboard_bundle() {
         "cfg_index should list analyzed PHP functions"
     );
 
-    let calls_count = manifest["graph"]["calls_count"].as_u64().unwrap_or(0);
+    let calls_count = manifest["metrics"]["calls_count"].as_u64().unwrap_or(0);
     assert!(calls_count > 0, "expected non-zero call graph edges");
 
     eprintln!(

--- a/tests/dashboard_ecommerce_php.rs
+++ b/tests/dashboard_ecommerce_php.rs
@@ -1,0 +1,68 @@
+//! Dashboard gate — **ecommerce-php** test project (CFG/PDG/taint on PHP).
+
+mod dashboard_harness;
+
+use dashboard_harness::{
+    assert_dashboard_bundle_all_analysis, default_php_repo, run_discover_all,
+};
+use rgctl_dashboard::dist_embedded;
+
+const PHP_MIN_NODES: u64 = 10;
+const PHP_MIN_FUNCTIONS: u64 = 5;
+const PHP_MIN_METANODES: u64 = 1;
+
+#[test]
+fn discover_all_writes_php_cfg_dashboard_bundle() {
+    if !dist_embedded() {
+        panic!(
+            "dashboard/dist not embedded — run ./scripts/build-dashboard.sh && cargo build --release"
+        );
+    }
+
+    let repo = default_php_repo();
+    if !repo.is_dir() {
+        eprintln!("skip: php test repo not found at {}", repo.display());
+        return;
+    }
+
+    let output = run_discover_all(&repo, Some("php"));
+    assert!(
+        output.status.success(),
+        "discover --all on ecommerce-php failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_dashboard_bundle_all_analysis(&repo, PHP_MIN_NODES, PHP_MIN_METANODES);
+
+    let manifest: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(repo.join(".rgctl/dashboard/manifest.json")).unwrap(),
+    )
+    .unwrap();
+    let functions = manifest["metrics"]["function_count"].as_u64().unwrap_or(0);
+    assert!(
+        functions >= PHP_MIN_FUNCTIONS,
+        "expected >= {PHP_MIN_FUNCTIONS} functions, got {functions}"
+    );
+
+    let cfg_index: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(repo.join(".rgctl/dashboard/cfg_index.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(cfg_index["available"], true);
+    assert!(
+        cfg_index["function_count"].as_u64().unwrap_or(0) > 0,
+        "cfg_index should list analyzed PHP functions"
+    );
+
+    let calls_count = manifest["graph"]["calls_count"].as_u64().unwrap_or(0);
+    assert!(calls_count > 0, "expected non-zero call graph edges");
+
+    eprintln!(
+        "ecommerce-php OK: {} nodes, {} functions, {} cfg functions, {} calls",
+        manifest["graph"]["node_count"],
+        functions,
+        cfg_index["function_count"],
+        calls_count
+    );
+}

--- a/tests/dashboard_harness.rs
+++ b/tests/dashboard_harness.rs
@@ -62,6 +62,11 @@ pub fn default_typescript_repo() -> PathBuf {
     in_tree_ecommerce("ecommerce-typescript")
 }
 
+/// Default PHP ecommerce test repo (override with env).
+pub fn default_php_repo() -> PathBuf {
+    in_tree_ecommerce("ecommerce-php")
+}
+
 pub fn golden_repo_path() -> PathBuf {
     env_rg("DASHBOARD_GOLDEN_REPO")
         .map(PathBuf::from)

--- a/tests/php_cfg_analysis.rs
+++ b/tests/php_cfg_analysis.rs
@@ -1,0 +1,40 @@
+//! PHP CFG analysis against the ecommerce-php fixture.
+
+use rgctl::analysis::{
+    ProgramDependenceGraph, build_cfg_for_function, cfg_language_id_from_path,
+};
+use std::path::Path;
+
+fn php_repo() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("rgctl-tests/ecommerce-php")
+}
+
+#[test]
+fn php_cfg_language_profile_maps_extension() {
+    let path = Path::new("src/Service/AuthService.php");
+    assert_eq!(cfg_language_id_from_path(path), Some("php"));
+}
+
+#[test]
+fn php_cfg_builds_auth_login_from_fixture() {
+    let repo = php_repo();
+    let file = repo.join("src/Service/AuthService.php");
+    assert!(file.is_file(), "fixture missing at {}", file.display());
+
+    let source = std::fs::read_to_string(&file).unwrap();
+    let cfg = build_cfg_for_function("php", &source, "login").expect("login CFG");
+    assert!(cfg.blocks.len() >= 3, "expected branching CFG for login");
+
+    let pdg = ProgramDependenceGraph::build(&cfg, source.as_bytes()).expect("login PDG");
+    assert!(!pdg.nodes.is_empty());
+}
+
+#[test]
+fn php_cfg_builds_process_order_field_write() {
+    let repo = php_repo();
+    let file = repo.join("src/Service/AuthService.php");
+    let source = std::fs::read_to_string(&file).unwrap();
+    let cfg = build_cfg_for_function("php", &source, "processOrder").expect("processOrder CFG");
+    assert!(!cfg.blocks.is_empty());
+}

--- a/tests/php_cfg_analysis.rs
+++ b/tests/php_cfg_analysis.rs
@@ -38,3 +38,40 @@ fn php_cfg_builds_process_order_field_write() {
     let cfg = build_cfg_for_function("php", &source, "processOrder").expect("processOrder CFG");
     assert!(!cfg.blocks.is_empty());
 }
+
+#[test]
+fn php_cfg_do_while_has_cycle() {
+    let code = r#"<?php
+function looped($x) {
+    do {
+        $x--;
+    } while ($x > 0);
+}
+"#;
+    let cfg = build_cfg_for_function("php", code, "looped").expect("do-while CFG");
+    assert!(cfg.has_cycle(), "do-while must produce a back-edge");
+}
+
+#[test]
+fn php_cfg_yield_expression_builds() {
+    let code = r#"<?php
+function gen() {
+    yield 1;
+    yield from [2, 3];
+}
+"#;
+    let cfg = build_cfg_for_function("php", code, "gen").expect("yield CFG");
+    assert!(!cfg.blocks.is_empty());
+}
+
+#[test]
+fn php_cfg_declare_strict_types_builds() {
+    let code = r#"<?php
+declare(strict_types=1);
+function f(): int {
+    return 1;
+}
+"#;
+    let cfg = build_cfg_for_function("php", code, "f").expect("declare CFG");
+    assert!(!cfg.blocks.is_empty());
+}

--- a/tests/php_taint.rs
+++ b/tests/php_taint.rs
@@ -1,0 +1,24 @@
+//! PHP taint integration against inline fixture code.
+
+use rgctl::analysis::{
+    ProgramDependenceGraph, TaintAnalyzer, TaintSink, TaintSource, build_cfg_for_function,
+};
+
+#[test]
+fn php_taint_get_to_sql_query() {
+    let code = r#"<?php
+function handle_request() {
+    $username = $_GET['username'];
+    $query = "SELECT * FROM users WHERE name = '" . $username . "'";
+    mysqli_query($conn, $query);
+}
+"#;
+    let cfg = build_cfg_for_function("php", code, "handle_request").unwrap();
+    let pdg = ProgramDependenceGraph::build(&cfg, code.as_bytes()).unwrap();
+    let mut analyzer = TaintAnalyzer::new(&pdg, &cfg);
+    analyzer.detect_patterns("php");
+    let flows = analyzer.vulnerable_flows();
+    assert!(!flows.is_empty(), "expected $_GET -> mysqli_query flow");
+    assert_eq!(flows[0].source_type, TaintSource::HttpParameter);
+    assert_eq!(flows[0].sink_type, TaintSink::SqlQuery);
+}

--- a/tests/php_taint.rs
+++ b/tests/php_taint.rs
@@ -22,3 +22,21 @@ function handle_request() {
     assert_eq!(flows[0].source_type, TaintSource::HttpParameter);
     assert_eq!(flows[0].sink_type, TaintSink::SqlQuery);
 }
+
+#[test]
+fn php_taint_files_to_shell() {
+    let code = r#"<?php
+function upload() {
+    $name = $_FILES['upload']['name'];
+    system("process " . $name);
+}
+"#;
+    let cfg = build_cfg_for_function("php", code, "upload").unwrap();
+    let pdg = ProgramDependenceGraph::build(&cfg, code.as_bytes()).unwrap();
+    let mut analyzer = TaintAnalyzer::new(&pdg, &cfg);
+    analyzer.detect_patterns("php");
+    let flows = analyzer.vulnerable_flows();
+    assert!(!flows.is_empty(), "expected $_FILES -> system flow");
+    assert_eq!(flows[0].source_type, TaintSource::HttpParameter);
+    assert_eq!(flows[0].sink_type, TaintSink::ShellCommand);
+}


### PR DESCRIPTION
## Summary

Adds **PHP** as the 10th Tier 1 language in rgctl: custom `PhpPlugin` (`tree-sitter-php`), full analysis pipeline (CFG, PDG, taint, Layer F field-write mutations), and an `ecommerce-php` reference fixture.

Closes #73

## What's included

### New crate: `rgctl-lang-php`
- Custom `LanguagePlugin` — functions, methods, arrow/anonymous functions
- Types: classes, interfaces, traits, enums with namespace-qualified names
- `__construct` → `Class.<init>`; promoted properties → `fields[]`
- Relations: `Calls`, `Extends`, `Implements`
- Complexity metrics (cyclomatic, cognitive, LOC, nesting)

### Analysis wiring (`rgctl-analysis`)
- PHP `LanguageAnalysisProfile` (`cfg_enabled`, `taint_enabled`)
- CFG builder tests for PHP `if` / branching
- Def-use: `variable_name`, `$`-stripped identifiers
- `detect_php_patterns()` — HTTP superglobals, file I/O, SQL/shell/eval sinks, common sanitizers
- Field-write / CPG: PHP visitor, `$` receiver lookup, namespace `\` in type matching

### Plugin API
- `PHP_CALL_KINDS` in `walk_calls`
- `callee_name` extended for `name` / `variable_name` nodes

### Fixture & tests
- `rgctl-tests/ecommerce-php/` — controller → service → repository MVC flow
- `tests/php_cfg_analysis.rs` — CFG/PDG on `AuthService::login`
- `tests/php_taint.rs` — `$_GET` → `mysqli_query` vulnerable flow
- `tests/dashboard_ecommerce_php.rs` — discover + dashboard gate
- 4 unit tests in `rgctl-lang-php`

### Docs
- `docs/languages.md`, `docs/tier-1-language-support.md`, `README.md`

## Honesty limits

No `include`/`require` resolution, trait linearization, magic-method dispatch, or Composer graph. Documented in `crates/rgctl-lang-php/src/lib.rs`.

## Follow-up (tracked in #73)

Trait `use` → `Uses`, namespace imports, anonymous classes, attributes, dynamic calls, const extraction, expanded taint/CFG — planned as a second pass after merge.

## Test plan

- [x] `cargo test -p rgctl-lang-php`
- [x] `cargo test php_cfg_analysis php_taint dashboard_ecommerce_php`
- [x] `rgctl discover rgctl-tests/ecommerce-php --with-cfg --with-taint` — 10 functions, calls graph, taint + field-write coverage
- [x] Full `cargo test` on CI
- [x] Manual smoke: `rgctl serve` + dashboard on ecommerce-php fixture

## Stats

**Branch:** `php-support` (1 commit: `95ddeec`)  
**Diff vs `main`:** 29 files, +1483 / −22


Made with [Cursor](https://cursor.com)